### PR TITLE
Remove SessionCheckpointer class, use AsyncSqliteSaver directly

### DIFF
--- a/nanobot_deep/cli.py
+++ b/nanobot_deep/cli.py
@@ -114,7 +114,11 @@ def gateway(
     if verbose:
         import logging
 
+        from loguru import logger
+
         logging.basicConfig(level=logging.DEBUG)
+        logger.enable("nanobot")
+        logger.enable("nanobot_deep")
 
     nanobot_config = _load_config(config, workspace)
 
@@ -168,20 +172,29 @@ def agent(
 
     from nanobot_deep.agent.deep_agent import DeepAgent
     from nanobot_deep.config.loader import load_deepagents_config
-    from nanobot_deep.langgraph.checkpointer import SessionCheckpointer
 
     db_path = nanobot_config.workspace_path.parent / "sessions.db"
-    checkpointer = SessionCheckpointer(db_path, migrate_from_json=True)
-    checkpointer.setup()
 
     deepagents_config = load_deepagents_config()
 
-    agent_instance = DeepAgent(
-        workspace=nanobot_config.workspace_path,
-        config=nanobot_config,
-        checkpointer=checkpointer,
-        deepagents_config=deepagents_config,
-    )
+    async def _create_checkpointer():
+        import aiosqlite
+
+        from langgraph.checkpoint.sqlite.aio import AsyncSqliteSaver
+
+        conn = await aiosqlite.connect(str(db_path))
+        checkpointer = AsyncSqliteSaver(conn)
+        await checkpointer.setup()
+        return checkpointer
+
+    async def _create_agent():
+        checkpointer = await _create_checkpointer()
+        return DeepAgent(
+            workspace=nanobot_config.workspace_path,
+            config=nanobot_config,
+            checkpointer=checkpointer,
+            deepagents_config=deepagents_config,
+        )
 
     def _print_response(response: str) -> None:
         content = response or ""
@@ -204,6 +217,7 @@ def agent(
     if message:
 
         async def run_once():
+            agent_instance = await _create_agent()
             with _thinking_ctx():
                 response = await agent_instance.process_direct(
                     message,
@@ -246,6 +260,7 @@ def agent(
             signal.signal(signal.SIGPIPE, signal.SIG_IGN)
 
         async def run_interactive():
+            agent_instance = await _create_agent()
             try:
                 while True:
                     try:

--- a/nanobot_deep/langgraph/bridge.py
+++ b/nanobot_deep/langgraph/bridge.py
@@ -20,8 +20,8 @@ from langgraph.graph.state import CompiledStateGraph
 from loguru import logger
 
 if TYPE_CHECKING:
+    from langgraph.checkpoint.sqlite.aio import AsyncSqliteSaver
     from nanobot.bus.events import InboundMessage, OutboundMessage
-    from nanobot_deep.langgraph.checkpointer import SessionCheckpointer
 
 
 def translate_inbound_to_state(
@@ -213,7 +213,7 @@ class LangGraphBridge:
     def __init__(
         self,
         agent: CompiledStateGraph,
-        checkpointer: "SessionCheckpointer",
+        checkpointer: "AsyncSqliteSaver",
         workspace: Path | None = None,
     ):
         self.agent = agent
@@ -358,16 +358,13 @@ class LangGraphBridge:
         response = await self.process(msg, on_progress=_progress)
         return response.content
 
-    def clear_session(self, session_key: str) -> bool:
+    def clear_session(self, session_key: str) -> None:
         """Clear a session's checkpoint history.
 
         Args:
             session_key: The session to clear
-
-        Returns:
-            True if session was deleted
         """
-        return self.checkpointer.delete_session(session_key)
+        self.checkpointer.delete_thread(session_key)
 
     def get_history(self, session_key: str, limit: int = 100) -> list[dict]:
         """Get message history for a session.
@@ -379,4 +376,6 @@ class LangGraphBridge:
         Returns:
             List of message dicts
         """
-        return self.checkpointer.get_session_history(session_key, limit)
+        from nanobot_deep.langgraph.checkpointer import get_session_history
+
+        return get_session_history(self.checkpointer, session_key, limit)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,6 +15,7 @@ dependencies = [
     "langgraph>=0.2.0",
     "langgraph-checkpoint-sqlite>=3.0.0",
     "langchain-core>=0.3.0",
+    "langchain-litellm>=0.6.0",
     "langchain-mcp-adapters>=0.1.0",
     "aiosqlite>=0.20.0",
 ]

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -5,10 +5,15 @@ Usage:
     export NANOBOT_CONFIG_PATH=~/.nanobot/config.json
     # Optional: Override DeepAgents config.toml path
     export DEEPAGENTS_CONFIG_PATH=~/.deepagents/config.toml
+    # Optional: Use minimal deepagents test config
+    export NANOBOT_TEST_DEEPAGENTS_CONFIG=tests/e2e/deepagents.test.json
     pytest tests/e2e/ -m live -v
 
     # Option 2: Override DeepAgents model
     DEEPAGENTS_TEST_MODEL=openai:gpt-4o-mini pytest tests/e2e/ -m live -v
+
+    # Option 3: Explicit nanobot config path
+    NANOBOT_TEST_CONFIG=~/.nanobot/config.json pytest tests/e2e/ -m live -v
 
     # Telegram E2E tests (require real Telegram user account):
     # 1. Get API credentials: https://my.telegram.org/apps
@@ -45,18 +50,22 @@ def pytest_configure(config):
 def nanobot_test_config() -> "Config":
     """Load nanobot config for tests.
 
-    Uses NANOBOT_CONFIG_PATH env var if set, otherwise default ~/.nanobot/config.json
+    Uses NANOBOT_TEST_CONFIG or NANOBOT_CONFIG_PATH if set, otherwise default
+    ~/.nanobot/config.json.
     """
     from nanobot.config.loader import load_config
 
-    config_path = os.environ.get("NANOBOT_CONFIG_PATH")
+    config_path = os.environ.get("NANOBOT_TEST_CONFIG") or os.environ.get("NANOBOT_CONFIG_PATH")
     if config_path:
         config_path = Path(config_path)
     else:
         config_path = Path.home() / ".nanobot" / "config.json"
 
     if not config_path.exists():
-        pytest.skip(f"Config not found at {config_path}. Set NANOBOT_CONFIG_PATH or create config.")
+        pytest.skip(
+            f"Config not found at {config_path}. Set NANOBOT_TEST_CONFIG or "
+            "NANOBOT_CONFIG_PATH, or create a default config."
+        )
 
     return load_config(config_path)
 
@@ -329,7 +338,16 @@ async def deep_checkpointer(workspace: Path):
 @pytest.fixture
 def deep_agent_config():
     """Create DeepAgents runtime config for live tests."""
+    from nanobot_deep.config.loader import load_deepagents_config
     from nanobot_deep.config.schema import DeepAgentsConfig
+
+    config_path = os.environ.get("NANOBOT_TEST_DEEPAGENTS_CONFIG")
+    if config_path:
+        return load_deepagents_config(Path(config_path).expanduser().resolve())
+
+    default_path = Path(__file__).parent / "deepagents.test.json"
+    if default_path.exists():
+        return load_deepagents_config(default_path)
 
     return DeepAgentsConfig(recursion_limit=50, debug=False)
 

--- a/tests/e2e/deepagents.test.json
+++ b/tests/e2e/deepagents.test.json
@@ -1,0 +1,47 @@
+{
+  "$schema": "../templates/deepagents.schema.json",
+  "model": {
+    "max_tokens": 1000,
+    "temperature": 1.0
+  },
+  "recursion_limit": 50,
+  "debug": false,
+  "name": "nanobot-deep-test-agent",
+  "backend": {
+    "restrict_to_workspace": false,
+    "exec_timeout": 30,
+    "path_append": ""
+  },
+  "checkpointer": {
+    "type": "sqlite",
+    "path": ""
+  },
+  "skills": [],
+  "memory": [],
+  "subagents": [],
+  "interrupt_on": {
+    "edit_file": false,
+    "write_file": false,
+    "execute": false,
+    "all_tools": false
+  },
+  "summarization": {
+    "enabled": false,
+    "trigger_tokens": 100000,
+    "keep_messages": 10
+  },
+  "middleware": {
+    "enable_todolist": false,
+    "enable_summarization": false,
+    "enable_prompt_caching": false,
+    "enable_skills": false,
+    "enable_memory": false,
+    "enable_subagents": false,
+    "enable_filesystem": true
+  },
+  "task_routing": {
+    "auto_delegate_reply_to": false,
+    "control_commands": [],
+    "delegate_threshold_tokens": 1000
+  }
+}

--- a/tests/e2e/test_deepagent_live.py
+++ b/tests/e2e/test_deepagent_live.py
@@ -1,0 +1,287 @@
+"""DeepAgent e2e tests with real LLM calls.
+
+Tests the full message flow: inbound -> DeepAgent -> outbound
+
+Run with:
+    NANOBOT_TEST_API_KEY=sk-... pytest tests/e2e/test_deepagent_live.py -m live -v
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+from nanobot.bus.events import InboundMessage
+
+pytestmark = pytest.mark.live
+
+
+class TestDeepAgentBasic:
+    """Basic DeepAgent functionality tests."""
+
+    @pytest.mark.asyncio
+    @pytest.mark.timeout(60)
+    async def test_simple_message(self, live_deep_gateway, send_and_wait):
+        """Test basic message processing through DeepAgent."""
+        bus = live_deep_gateway["bus"]
+
+        response = await send_and_wait(bus, "Reply with exactly the word 'pong' and nothing else")
+
+        assert response.channel == "test"
+        assert response.chat_id == "chat1"
+        assert "pong" in response.content.lower()
+
+    @pytest.mark.asyncio
+    @pytest.mark.timeout(60)
+    async def test_message_routing(self, live_deep_gateway):
+        """Test message is routed to correct channel/chat."""
+        bus = live_deep_gateway["bus"]
+
+        await bus.publish_inbound(
+            InboundMessage(
+                channel="test_channel",
+                sender_id="test_sender",
+                chat_id="test_chat_123",
+                content="Say 'hello'",
+            )
+        )
+
+        response = await asyncio.wait_for(bus.consume_outbound(), timeout=30)
+
+        assert response.channel == "test_channel"
+        assert response.chat_id == "test_chat_123"
+        assert "hello" in response.content.lower()
+
+
+class TestDeepAgentSlashCommands:
+    """Test slash commands through DeepAgent."""
+
+    @pytest.mark.asyncio
+    @pytest.mark.timeout(30)
+    async def test_help_command(self, live_deep_gateway, send_and_wait):
+        """Test /help command."""
+        bus = live_deep_gateway["bus"]
+
+        response = await send_and_wait(bus, "/help")
+
+        assert response.channel == "test"
+        content_lower = response.content.lower()
+        assert any(word in content_lower for word in ["help", "commands", "usage"])
+
+    @pytest.mark.asyncio
+    @pytest.mark.timeout(30)
+    async def test_new_command(self, live_deep_gateway, send_and_wait):
+        """Test /new command clears session."""
+        bus = live_deep_gateway["bus"]
+
+        response = await send_and_wait(bus, "/new")
+
+        assert response.channel == "test"
+        content_lower = response.content.lower()
+        assert any(word in content_lower for word in ["new", "session", "cleared", "started"])
+
+
+class TestDeepAgentConversation:
+    """Test conversation history and session persistence."""
+
+    @pytest.mark.asyncio
+    @pytest.mark.timeout(120)
+    async def test_remember_name(self, live_deep_gateway, send_and_wait):
+        """Test agent remembers name across turns."""
+        bus = live_deep_gateway["bus"]
+
+        r1 = await send_and_wait(
+            bus, "My name is Alice. Just acknowledge briefly.", chat_id="memory_test"
+        )
+        assert r1.content
+
+        r2 = await send_and_wait(bus, "What is my name?", chat_id="memory_test")
+
+        assert "alice" in r2.content.lower()
+
+    @pytest.mark.asyncio
+    @pytest.mark.timeout(120)
+    async def test_session_isolation(self, live_deep_gateway, send_and_wait):
+        """Test different sessions don't share context."""
+        bus = live_deep_gateway["bus"]
+
+        await send_and_wait(bus, "My name is Alice.", chat_id="session_a")
+        await send_and_wait(bus, "My name is Bob.", chat_id="session_b")
+
+        r_a = await send_and_wait(bus, "What is my name?", chat_id="session_a")
+        r_b = await send_and_wait(bus, "What is my name?", chat_id="session_b")
+
+        assert "alice" in r_a.content.lower()
+        assert "bob" in r_b.content.lower()
+
+
+class TestDeepAgentFileOperations:
+    """Test file operations through DeepAgent."""
+
+    @pytest.mark.asyncio
+    @pytest.mark.timeout(90)
+    async def test_write_file(self, live_deep_gateway, workspace, send_and_wait):
+        """Test writing a file through DeepAgent."""
+        bus = live_deep_gateway["bus"]
+
+        await send_and_wait(
+            bus, "Create a file called test_write.txt with the content 'Written by DeepAgent'"
+        )
+
+        written_file = workspace / "test_write.txt"
+        assert written_file.exists(), f"File not created in {workspace}"
+        assert "Written by DeepAgent" in written_file.read_text()
+
+    @pytest.mark.asyncio
+    @pytest.mark.timeout(90)
+    async def test_read_file(self, live_deep_gateway, workspace, send_and_wait):
+        """Test reading a file through DeepAgent."""
+        bus = live_deep_gateway["bus"]
+
+        test_file = workspace / "test_read.txt"
+        test_file.write_text("Hello from DeepAgent!")
+
+        response = await send_and_wait(bus, "Read the file test_read.txt and tell me what it says")
+
+        assert "Hello from DeepAgent" in response.content
+
+    @pytest.mark.asyncio
+    @pytest.mark.timeout(90)
+    async def test_edit_file(self, live_deep_gateway, workspace, send_and_wait):
+        """Test editing a file through DeepAgent."""
+        bus = live_deep_gateway["bus"]
+
+        test_file = workspace / "test_edit.txt"
+        test_file.write_text("Original content here")
+
+        await send_and_wait(
+            bus, "Edit the file test_edit.txt and replace 'Original' with 'Modified'"
+        )
+
+        content = test_file.read_text()
+        assert "Modified" in content
+        assert "Original" not in content
+
+
+class TestDeepAgentErrorHandling:
+    """Test error handling in DeepAgent."""
+
+    @pytest.mark.asyncio
+    @pytest.mark.timeout(60)
+    async def test_handles_nonexistent_file(self, live_deep_gateway, send_and_wait):
+        """Test DeepAgent handles non-existent file gracefully."""
+        bus = live_deep_gateway["bus"]
+
+        response = await send_and_wait(
+            bus, "Try to read a file called nonexistent_file_12345.txt and report what happens"
+        )
+
+        content_lower = response.content.lower()
+        assert any(
+            word in content_lower
+            for word in ["not found", "does not exist", "error", "cannot", "unable"]
+        )
+
+
+class TestDeepAgentDebugging:
+    """Tests for debugging agent behavior."""
+
+    @pytest.mark.asyncio
+    @pytest.mark.timeout(60)
+    async def test_response_not_empty(self, live_deep_gateway, send_and_wait):
+        """Test that response is not empty."""
+        bus = live_deep_gateway["bus"]
+
+        response = await send_and_wait(bus, "Say hello")
+
+        assert response.content, "Response content should not be empty"
+        assert len(response.content) > 0, "Response content should have length > 0"
+
+    @pytest.mark.asyncio
+    @pytest.mark.timeout(60)
+    async def test_response_channel_matches(self, live_deep_gateway, send_and_wait):
+        """Test that response channel matches request channel."""
+        bus = live_deep_gateway["bus"]
+
+        response = await send_and_wait(
+            bus, "Reply with OK", channel="debug_channel", chat_id="debug_chat"
+        )
+
+        assert response.channel == "debug_channel"
+        assert response.chat_id == "debug_chat"
+
+    @pytest.mark.asyncio
+    @pytest.mark.timeout(90)
+    async def test_agent_processes_tool_calls(self, live_deep_gateway, workspace, send_and_wait):
+        """Test that agent can use tools successfully."""
+        bus = live_deep_gateway["bus"]
+
+        response = await send_and_wait(
+            bus, "Create a file called debug_test.txt with content 'test passed'"
+        )
+
+        assert response.content, "Response should not be empty after tool use"
+
+        debug_file = workspace / "debug_test.txt"
+        assert debug_file.exists(), f"File should be created in {workspace}"
+        assert "test passed" in debug_file.read_text()
+
+    @pytest.mark.asyncio
+    @pytest.mark.timeout(60)
+    async def test_agent_returns_proper_structure(self, live_deep_gateway, send_and_wait):
+        """Test that response has proper OutboundMessage structure."""
+        from nanobot.bus.events import OutboundMessage
+
+        bus = live_deep_gateway["bus"]
+
+        response = await send_and_wait(bus, "Reply with the word 'structure'")
+
+        assert isinstance(response, OutboundMessage)
+        assert hasattr(response, "channel")
+        assert hasattr(response, "chat_id")
+        assert hasattr(response, "content")
+        assert hasattr(response, "metadata")
+        assert response.channel is not None
+        assert response.chat_id is not None
+        assert response.content is not None
+
+    @pytest.mark.asyncio
+    @pytest.mark.timeout(90)
+    async def test_agent_handles_multiline_response(self, live_deep_gateway, send_and_wait):
+        """Test that agent can return multiline responses."""
+        bus = live_deep_gateway["bus"]
+
+        response = await send_and_wait(
+            bus, "Write a short 3-line poem about robots. Each line on a new line."
+        )
+
+        assert "\n" in response.content or len(response.content) > 20, (
+            "Response should be multiline or substantial"
+        )
+
+    @pytest.mark.asyncio
+    @pytest.mark.timeout(120)
+    async def test_agent_maintains_context_in_session(self, live_deep_gateway, send_and_wait):
+        """Test that agent maintains context within a session."""
+        bus = live_deep_gateway["bus"]
+
+        await send_and_wait(bus, "Remember the secret code is ALPHA-123", chat_id="context_test")
+
+        response = await send_and_wait(
+            bus, "What is the secret code I just told you?", chat_id="context_test"
+        )
+
+        assert "alpha" in response.content.lower() or "123" in response.content
+
+    @pytest.mark.asyncio
+    @pytest.mark.timeout(60)
+    async def test_error_message_is_informative(self, live_deep_gateway, send_and_wait):
+        """Test that error messages are informative when things fail."""
+        bus = live_deep_gateway["bus"]
+
+        response = await send_and_wait(
+            bus, "Try to read a file that definitely does not exist: /nonexistent/path/xyz123.txt"
+        )
+
+        assert response.content, "Should have some response even on error"
+        assert len(response.content) > 5, "Error message should be informative"

--- a/tests/test_bridge.py
+++ b/tests/test_bridge.py
@@ -1,0 +1,487 @@
+"""Unit tests for bridge.py message translation functions."""
+
+from __future__ import annotations
+
+import pytest
+
+from langchain_core.messages import HumanMessage, AIMessage, ToolMessage, SystemMessage
+
+
+class TestTranslateInboundToState:
+    """Tests for translate_inbound_to_state function."""
+
+    def test_simple_text_message(self):
+        """Test basic text message conversion."""
+        from nanobot.bus.events import InboundMessage
+        from nanobot_deep.langgraph.bridge import translate_inbound_to_state
+
+        msg = InboundMessage(
+            channel="telegram",
+            sender_id="user123",
+            chat_id="chat456",
+            content="Hello, world!",
+        )
+
+        state = translate_inbound_to_state(msg)
+
+        assert "messages" in state
+        assert len(state["messages"]) == 1
+        assert isinstance(state["messages"][0], HumanMessage)
+        assert state["messages"][0].content == "Hello, world!"
+
+    def test_message_with_system_prompt(self):
+        """Test message with system prompt prepended."""
+        from nanobot.bus.events import InboundMessage
+        from nanobot_deep.langgraph.bridge import translate_inbound_to_state
+
+        msg = InboundMessage(
+            channel="cli",
+            sender_id="user",
+            chat_id="test",
+            content="Test message",
+        )
+
+        state = translate_inbound_to_state(msg, system_prompt="You are a helpful assistant.")
+
+        assert len(state["messages"]) == 2
+        assert isinstance(state["messages"][0], SystemMessage)
+        assert state["messages"][0].content == "You are a helpful assistant."
+        assert isinstance(state["messages"][1], HumanMessage)
+
+    def test_message_with_history(self):
+        """Test message with conversation history."""
+        from nanobot.bus.events import InboundMessage
+        from nanobot_deep.langgraph.bridge import translate_inbound_to_state
+
+        msg = InboundMessage(
+            channel="test",
+            sender_id="user",
+            chat_id="chat",
+            content="What about now?",
+        )
+
+        history = [
+            {"role": "user", "content": "Hello"},
+            {"role": "assistant", "content": "Hi there!"},
+        ]
+
+        state = translate_inbound_to_state(msg, history=history)
+
+        assert len(state["messages"]) == 3
+        assert isinstance(state["messages"][0], HumanMessage)
+        assert state["messages"][0].content == "Hello"
+        assert isinstance(state["messages"][1], AIMessage)
+        assert state["messages"][1].content == "Hi there!"
+        assert isinstance(state["messages"][2], HumanMessage)
+
+    def test_message_with_reply_context(self):
+        """Test message with reply-to context."""
+        from nanobot.bus.events import InboundMessage
+        from nanobot_deep.langgraph.bridge import translate_inbound_to_state
+
+        msg = InboundMessage(
+            channel="telegram",
+            sender_id="user123",
+            chat_id="chat456",
+            content="Yes, I agree",
+        )
+
+        reply_context = {
+            "text": "Do you agree with this proposal?",
+            "from_username": "manager",
+        }
+
+        state = translate_inbound_to_state(msg, reply_context=reply_context)
+
+        assert len(state["messages"]) == 2
+        assert isinstance(state["messages"][0], SystemMessage)
+        assert "manager" in state["messages"][0].content
+        assert "Do you agree with this proposal?" in state["messages"][0].content
+
+
+class TestTranslateResultToOutbound:
+    """Tests for translate_result_to_outbound function."""
+
+    def test_simple_ai_response(self):
+        """Test converting simple AI response."""
+        from nanobot.bus.events import InboundMessage
+        from nanobot_deep.langgraph.bridge import translate_result_to_outbound
+
+        msg = InboundMessage(
+            channel="telegram",
+            sender_id="user123",
+            chat_id="chat456",
+            content="Hello",
+        )
+
+        result = {
+            "messages": [
+                HumanMessage(content="Hello"),
+                AIMessage(content="Hi there! How can I help you?"),
+            ]
+        }
+
+        outbound = translate_result_to_outbound(result, msg)
+
+        assert outbound.channel == "telegram"
+        assert outbound.chat_id == "chat456"
+        assert outbound.content == "Hi there! How can I help you?"
+
+    def test_result_with_tool_messages(self):
+        """Test result with tool messages finds AI response."""
+        from nanobot.bus.events import InboundMessage
+        from langchain_core.messages import ToolCall
+        from nanobot_deep.langgraph.bridge import translate_result_to_outbound
+
+        msg = InboundMessage(
+            channel="test",
+            sender_id="user",
+            chat_id="chat",
+            content="Read the file",
+        )
+
+        result = {
+            "messages": [
+                HumanMessage(content="Read the file"),
+                AIMessage(
+                    content="",
+                    tool_calls=[
+                        ToolCall(name="read_file", args={"path": "test.txt"}, id="call_123")
+                    ],
+                ),
+                ToolMessage(content="File contents here", tool_call_id="call_123"),
+                AIMessage(content="The file contains: File contents here"),
+            ]
+        }
+
+        outbound = translate_result_to_outbound(result, msg)
+
+        assert outbound.content == "The file contains: File contents here"
+
+    def test_empty_result(self):
+        """Test handling of empty result."""
+        from nanobot.bus.events import InboundMessage
+        from nanobot_deep.langgraph.bridge import translate_result_to_outbound
+
+        msg = InboundMessage(
+            channel="test",
+            sender_id="user",
+            chat_id="chat",
+            content="Test",
+        )
+
+        result = {"messages": []}
+
+        outbound = translate_result_to_outbound(result, msg)
+
+        assert outbound.content == ""
+
+    def test_preserves_metadata(self):
+        """Test that metadata is preserved in outbound."""
+        from nanobot.bus.events import InboundMessage
+        from nanobot_deep.langgraph.bridge import translate_result_to_outbound
+
+        msg = InboundMessage(
+            channel="test",
+            sender_id="user",
+            chat_id="chat",
+            content="Test",
+            metadata={"original_message_id": "msg123"},
+        )
+
+        result = {"messages": [AIMessage(content="Response")]}
+
+        outbound = translate_result_to_outbound(result, msg)
+
+        assert outbound.metadata.get("original_message_id") == "msg123"
+
+
+class TestExtractReplyContext:
+    """Tests for extract_reply_context function."""
+
+    def test_no_metadata(self):
+        """Test message without metadata."""
+        from nanobot.bus.events import InboundMessage
+        from nanobot_deep.langgraph.bridge import extract_reply_context
+
+        msg = InboundMessage(
+            channel="test",
+            sender_id="user",
+            chat_id="chat",
+            content="Hello",
+        )
+
+        assert extract_reply_context(msg) is None
+
+    def test_with_reply_context(self):
+        """Test message with reply context."""
+        from nanobot.bus.events import InboundMessage
+        from nanobot_deep.langgraph.bridge import extract_reply_context
+
+        msg = InboundMessage(
+            channel="telegram",
+            sender_id="user123",
+            chat_id="chat456",
+            content="Yes",
+            metadata={
+                "reply_to_message": {
+                    "message_id": "orig_123",
+                    "text": "Question?",
+                    "from_username": "other_user",
+                }
+            },
+        )
+
+        context = extract_reply_context(msg)
+
+        assert context is not None
+        assert context["text"] == "Question?"
+        assert context["from_username"] == "other_user"
+
+
+class TestShouldDelegateTask:
+    """Tests for should_delegate_task function."""
+
+    def test_control_command_not_delegated(self):
+        """Test control commands are not delegated."""
+        from nanobot.bus.events import InboundMessage
+        from nanobot_deep.langgraph.bridge import should_delegate_task
+
+        msg = InboundMessage(
+            channel="test",
+            sender_id="user",
+            chat_id="chat",
+            content="/help",
+        )
+
+        should, delegate_type = should_delegate_task(
+            msg, control_commands=["/help", "/new", "/stop"]
+        )
+
+        assert should is False
+        assert delegate_type == "control"
+
+    def test_reply_message_delegated(self):
+        """Test reply messages are delegated when enabled."""
+        from nanobot.bus.events import InboundMessage
+        from nanobot_deep.langgraph.bridge import should_delegate_task
+
+        msg = InboundMessage(
+            channel="telegram",
+            sender_id="user",
+            chat_id="chat",
+            content="Yes, I agree",
+            metadata={
+                "reply_to_message": {
+                    "text": "Do you agree?",
+                }
+            },
+        )
+
+        should, delegate_type = should_delegate_task(
+            msg, control_commands=["/help"], auto_delegate_reply=True
+        )
+
+        assert should is True
+        assert delegate_type == "reply"
+
+    def test_reply_delegation_disabled(self):
+        """Test reply messages not delegated when disabled."""
+        from nanobot.bus.events import InboundMessage
+        from nanobot_deep.langgraph.bridge import should_delegate_task
+
+        msg = InboundMessage(
+            channel="test",
+            sender_id="user",
+            chat_id="chat",
+            content="Yes",
+            metadata={"reply_to_message": {"text": "Question?"}},
+        )
+
+        should, delegate_type = should_delegate_task(
+            msg, control_commands=[], auto_delegate_reply=False
+        )
+
+        assert should is False
+        assert delegate_type == "main"
+
+    def test_regular_message_not_delegated(self):
+        """Test regular messages are not delegated."""
+        from nanobot.bus.events import InboundMessage
+        from nanobot_deep.langgraph.bridge import should_delegate_task
+
+        msg = InboundMessage(
+            channel="test",
+            sender_id="user",
+            chat_id="chat",
+            content="Tell me a joke",
+        )
+
+        should, delegate_type = should_delegate_task(msg, control_commands=["/help", "/new"])
+
+        assert should is False
+        assert delegate_type == "main"
+
+
+class TestFullMessageFlow:
+    """Tests for complete message flow through bridge functions."""
+
+    def test_inbound_to_outbound_roundtrip(self):
+        """Test complete roundtrip: InboundMessage -> State -> Result -> OutboundMessage."""
+        from nanobot.bus.events import InboundMessage
+        from nanobot_deep.langgraph.bridge import (
+            translate_inbound_to_state,
+            translate_result_to_outbound,
+        )
+
+        msg = InboundMessage(
+            channel="telegram",
+            sender_id="tg_user_123",
+            chat_id="tg_chat_456",
+            content="What is the weather?",
+            metadata={"user_name": "Alice"},
+        )
+
+        state = translate_inbound_to_state(msg)
+
+        result = {
+            "messages": [
+                state["messages"][0],
+                AIMessage(content="I don't have access to weather data."),
+            ]
+        }
+
+        outbound = translate_result_to_outbound(result, msg)
+
+        assert outbound.channel == "telegram"
+        assert outbound.chat_id == "tg_chat_456"
+        assert "weather" in outbound.content.lower()
+        assert outbound.metadata.get("user_name") == "Alice"
+
+
+class TestEdgeCases:
+    """Tests for edge cases in message translation."""
+
+    def test_empty_content(self):
+        """Test handling of empty message content."""
+        from nanobot.bus.events import InboundMessage
+        from nanobot_deep.langgraph.bridge import translate_inbound_to_state
+
+        msg = InboundMessage(
+            channel="test",
+            sender_id="user",
+            chat_id="chat",
+            content="",
+        )
+
+        state = translate_inbound_to_state(msg)
+
+        assert len(state["messages"]) == 1
+        assert state["messages"][0].content == ""
+
+    def test_very_long_content(self):
+        """Test handling of very long message content."""
+        from nanobot.bus.events import InboundMessage
+        from nanobot_deep.langgraph.bridge import translate_inbound_to_state
+
+        long_content = "x" * 10000
+        msg = InboundMessage(
+            channel="test",
+            sender_id="user",
+            chat_id="chat",
+            content=long_content,
+        )
+
+        state = translate_inbound_to_state(msg)
+
+        assert len(state["messages"]) == 1
+        assert state["messages"][0].content == long_content
+
+    def test_special_characters_in_content(self):
+        """Test handling of special characters in content."""
+        from nanobot.bus.events import InboundMessage
+        from nanobot_deep.langgraph.bridge import translate_inbound_to_state
+
+        special_content = "Hello\n\tWorld! @#$%^&*() 你好"
+        msg = InboundMessage(
+            channel="test",
+            sender_id="user",
+            chat_id="chat",
+            content=special_content,
+        )
+
+        state = translate_inbound_to_state(msg)
+
+        assert state["messages"][0].content == special_content
+
+    def test_tool_message_in_history(self):
+        """Test handling of tool messages in history."""
+        from nanobot.bus.events import InboundMessage
+        from nanobot_deep.langgraph.bridge import translate_inbound_to_state
+
+        msg = InboundMessage(
+            channel="test",
+            sender_id="user",
+            chat_id="chat",
+            content="What happened?",
+        )
+
+        history = [
+            {"role": "user", "content": "Read file"},
+            {
+                "role": "assistant",
+                "content": "",
+                "tool_calls": [{"id": "call_1", "name": "read_file", "args": {"path": "test.txt"}}],
+            },
+            {"role": "tool", "content": "File contents", "tool_call_id": "call_1"},
+        ]
+
+        state = translate_inbound_to_state(msg, history=history)
+
+        assert len(state["messages"]) == 4
+        assert isinstance(state["messages"][2], ToolMessage)
+
+    def test_result_with_only_tool_message(self):
+        """Test result that only has tool messages, no AI response."""
+        from nanobot.bus.events import InboundMessage
+        from nanobot_deep.langgraph.bridge import translate_result_to_outbound
+
+        msg = InboundMessage(
+            channel="test",
+            sender_id="user",
+            chat_id="chat",
+            content="Test",
+        )
+
+        result = {
+            "messages": [
+                HumanMessage(content="Test"),
+                ToolMessage(content="Tool output", tool_call_id="call_1"),
+            ]
+        }
+
+        outbound = translate_result_to_outbound(result, msg)
+
+        assert outbound.channel == "test"
+        assert outbound.chat_id == "chat"
+
+    def test_result_with_non_message_objects(self):
+        """Test result with objects that have content attribute."""
+        from nanobot.bus.events import InboundMessage
+        from nanobot_deep.langgraph.bridge import translate_result_to_outbound
+
+        msg = InboundMessage(
+            channel="test",
+            sender_id="user",
+            chat_id="chat",
+            content="Test",
+        )
+
+        class FakeMessage:
+            content = "Fake response"
+
+        result = {"messages": [FakeMessage()]}
+
+        outbound = translate_result_to_outbound(result, msg)
+
+        assert outbound.content == "Fake response"

--- a/tests/test_deep_agent.py
+++ b/tests/test_deep_agent.py
@@ -1,0 +1,449 @@
+"""Unit tests for DeepAgent class."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+
+class TestDeepAgentInit:
+    """Tests for DeepAgent initialization."""
+
+    def test_init_without_deepagents_raises(self, tmp_path):
+        """Test that initialization fails without deepagents installed."""
+        with patch("nanobot_deep.agent.deep_agent.DEEPAGENTS_AVAILABLE", False):
+            with patch("nanobot_deep.agent.deep_agent.create_deep_agent", None):
+                from nanobot_deep.agent.deep_agent import DeepAgent
+
+                config = self._create_mock_config(tmp_path)
+                with pytest.raises(ImportError, match="deepagents is not installed"):
+                    DeepAgent(workspace=tmp_path, config=config)
+
+    def test_init_with_valid_config(self, tmp_path):
+        """Test successful initialization with valid config."""
+        from nanobot_deep.agent.deep_agent import DeepAgent
+        from nanobot_deep.config.schema import DeepAgentsConfig
+
+        config = self._create_mock_config(tmp_path)
+        dg_config = DeepAgentsConfig()
+
+        with patch("nanobot_deep.agent.deep_agent.DEEPAGENTS_AVAILABLE", True):
+            agent = DeepAgent(
+                workspace=tmp_path,
+                config=config,
+                checkpointer=None,
+                deepagents_config=dg_config,
+            )
+
+            assert agent.workspace == tmp_path
+            assert agent.config == config
+            assert agent.checkpointer is None
+            assert agent._agent is None
+
+    def test_init_merges_nanobot_config(self, tmp_path):
+        """Test that config is merged with nanobot config."""
+        from nanobot_deep.agent.deep_agent import DeepAgent
+        from nanobot_deep.config.schema import DeepAgentsConfig
+
+        config = self._create_mock_config(tmp_path)
+        dg_config = DeepAgentsConfig()
+
+        with patch("nanobot_deep.agent.deep_agent.DEEPAGENTS_AVAILABLE", True):
+            agent = DeepAgent(
+                workspace=tmp_path,
+                config=config,
+                deepagents_config=dg_config,
+            )
+
+            assert agent.dg_config is not None
+
+    def _create_mock_config(self, workspace_path):
+        """Create a mock config with required attributes."""
+        config = MagicMock()
+        config.workspace_path = workspace_path
+        config.agents = MagicMock()
+        config.agents.defaults = MagicMock()
+        config.agents.defaults.model = "test-model"
+        config.agents.defaults.max_tool_iterations = 10
+        config.tools = MagicMock()
+        config.tools.mcp_servers = {}
+        config.get_provider = MagicMock(return_value=None)
+        return config
+
+
+class TestDeepAgentModelInit:
+    """Tests for model initialization."""
+
+    def test_model_init_from_deepagents_config(self, tmp_path):
+        """Test model initialization from deepagents config."""
+        from nanobot_deep.agent.deep_agent import DeepAgent
+        from nanobot_deep.config.schema import DeepAgentsConfig, DeepAgentsModelConfig
+
+        config = self._create_mock_config(tmp_path)
+        dg_config = DeepAgentsConfig(
+            model=DeepAgentsModelConfig(
+                name="openai/gpt-4",
+                max_tokens=1000,
+                temperature=0.5,
+            )
+        )
+
+        with patch("nanobot_deep.agent.deep_agent.DEEPAGENTS_AVAILABLE", True):
+            agent = DeepAgent(
+                workspace=tmp_path,
+                config=config,
+                deepagents_config=dg_config,
+            )
+
+            with patch("langchain_litellm.ChatLiteLLM") as mock_llm:
+                agent._init_model()
+                mock_llm.assert_called_once()
+                call_kwargs = mock_llm.call_args.kwargs
+                assert call_kwargs["model"] == "openai/gpt-4"
+                assert call_kwargs["max_tokens"] == 1000
+                assert call_kwargs["temperature"] == 0.5
+
+    def test_model_init_fallback_to_nanobot_config(self, tmp_path):
+        """Test model initialization falls back to nanobot config."""
+        from nanobot_deep.agent.deep_agent import DeepAgent
+        from nanobot_deep.config.schema import DeepAgentsConfig
+
+        config = self._create_mock_config(tmp_path)
+        config.agents.defaults.model = "anthropic/claude-sonnet-4-5"
+
+        provider_config = MagicMock()
+        provider_config.api_key = "test-key"
+        provider_config.api_base = "https://api.test.com"
+        config.get_provider = MagicMock(return_value=provider_config)
+
+        dg_config = DeepAgentsConfig()
+
+        with patch("nanobot_deep.agent.deep_agent.DEEPAGENTS_AVAILABLE", True):
+            agent = DeepAgent(
+                workspace=tmp_path,
+                config=config,
+                deepagents_config=dg_config,
+            )
+
+            with patch("langchain_litellm.ChatLiteLLM") as mock_llm:
+                agent._init_model()
+                call_kwargs = mock_llm.call_args.kwargs
+                assert call_kwargs["model"] == "anthropic/claude-sonnet-4-5"
+                assert call_kwargs["api_key"] == "test-key"
+                assert call_kwargs["api_base"] == "https://api.test.com"
+
+    def test_model_init_default_model(self, tmp_path):
+        """Test model initialization uses default when no model specified."""
+        from nanobot_deep.agent.deep_agent import DeepAgent
+        from nanobot_deep.config.schema import DeepAgentsConfig
+
+        config = self._create_mock_config(tmp_path)
+        config.agents.defaults.model = None
+        config.get_provider = MagicMock(return_value=None)
+
+        dg_config = DeepAgentsConfig()
+
+        with patch("nanobot_deep.agent.deep_agent.DEEPAGENTS_AVAILABLE", True):
+            agent = DeepAgent(
+                workspace=tmp_path,
+                config=config,
+                deepagents_config=dg_config,
+            )
+
+            with patch("langchain_litellm.ChatLiteLLM") as mock_llm:
+                agent._init_model()
+                call_kwargs = mock_llm.call_args.kwargs
+                assert call_kwargs["model"] == "anthropic/claude-sonnet-4-5"
+
+    def _create_mock_config(self, workspace_path):
+        config = MagicMock()
+        config.workspace_path = workspace_path
+        config.agents = MagicMock()
+        config.agents.defaults = MagicMock()
+        config.agents.defaults.model = "test-model"
+        config.agents.defaults.max_tool_iterations = 10
+        config.tools = MagicMock()
+        config.tools.mcp_servers = {}
+        config.get_provider = MagicMock(return_value=None)
+        return config
+
+
+class TestDeepAgentProcess:
+    """Tests for message processing."""
+
+    @pytest.mark.asyncio
+    async def test_process_returns_outbound_message(self, tmp_path):
+        """Test that process returns an OutboundMessage."""
+        from nanobot.bus.events import InboundMessage, OutboundMessage
+
+        from nanobot_deep.agent.deep_agent import DeepAgent
+        from nanobot_deep.config.schema import DeepAgentsConfig
+
+        config = self._create_mock_config(tmp_path)
+        dg_config = DeepAgentsConfig()
+
+        with patch("nanobot_deep.agent.deep_agent.DEEPAGENTS_AVAILABLE", True):
+            agent = DeepAgent(
+                workspace=tmp_path,
+                config=config,
+                deepagents_config=dg_config,
+            )
+
+            mock_compiled = AsyncMock()
+            mock_compiled.ainvoke.return_value = {
+                "messages": [MagicMock(content="Test response", type="ai")]
+            }
+            agent._agent = mock_compiled
+
+            msg = InboundMessage(
+                channel="cli",
+                sender_id="user",
+                chat_id="test",
+                content="Hello",
+            )
+
+            response = await agent.process(msg)
+
+            assert isinstance(response, OutboundMessage)
+            assert response.channel == "cli"
+            assert response.chat_id == "test"
+
+    @pytest.mark.asyncio
+    async def test_process_handles_exception(self, tmp_path):
+        """Test that process handles exceptions gracefully."""
+        from nanobot.bus.events import InboundMessage, OutboundMessage
+
+        from nanobot_deep.agent.deep_agent import DeepAgent
+        from nanobot_deep.config.schema import DeepAgentsConfig
+
+        config = self._create_mock_config(tmp_path)
+        dg_config = DeepAgentsConfig()
+
+        with patch("nanobot_deep.agent.deep_agent.DEEPAGENTS_AVAILABLE", True):
+            agent = DeepAgent(
+                workspace=tmp_path,
+                config=config,
+                deepagents_config=dg_config,
+            )
+
+            mock_compiled = AsyncMock()
+            mock_compiled.ainvoke.side_effect = Exception("API error")
+            agent._agent = mock_compiled
+
+            msg = InboundMessage(
+                channel="cli",
+                sender_id="user",
+                chat_id="test",
+                content="Hello",
+            )
+
+            response = await agent.process(msg)
+
+            assert isinstance(response, OutboundMessage)
+            assert "error" in response.content.lower()
+
+    @pytest.mark.asyncio
+    async def test_process_with_progress_callback(self, tmp_path):
+        """Test that process calls progress callback."""
+        from nanobot.bus.events import InboundMessage
+
+        from nanobot_deep.agent.deep_agent import DeepAgent
+        from nanobot_deep.config.schema import DeepAgentsConfig
+
+        config = self._create_mock_config(tmp_path)
+        dg_config = DeepAgentsConfig()
+
+        with patch("nanobot_deep.agent.deep_agent.DEEPAGENTS_AVAILABLE", True):
+            agent = DeepAgent(
+                workspace=tmp_path,
+                config=config,
+                deepagents_config=dg_config,
+            )
+
+            mock_compiled = AsyncMock()
+            mock_compiled.astream_events = AsyncMock()
+            mock_compiled.astream_events.return_value = self._mock_stream_events()
+            agent._agent = mock_compiled
+
+            msg = InboundMessage(
+                channel="cli",
+                sender_id="user",
+                chat_id="test",
+                content="Hello",
+            )
+
+            progress_calls = []
+
+            async def on_progress(text: str, is_tool_hint: bool = False):
+                progress_calls.append((text, is_tool_hint))
+
+            await agent.process(msg, on_progress=on_progress)
+
+    def _mock_stream_events(self):
+        """Generate mock stream events."""
+
+        async def _gen():
+            yield {
+                "event": "on_chain_end",
+                "name": "LangGraph",
+                "data": {"output": {"messages": []}},
+            }
+
+        return _gen()
+
+    def _create_mock_config(self, workspace_path):
+        config = MagicMock()
+        config.workspace_path = workspace_path
+        config.agents = MagicMock()
+        config.agents.defaults = MagicMock()
+        config.agents.defaults.model = "test-model"
+        config.agents.defaults.max_tool_iterations = 10
+        config.tools = MagicMock()
+        config.tools.mcp_servers = {}
+        config.get_provider = MagicMock(return_value=None)
+        return config
+
+
+class TestDeepAgentSession:
+    """Tests for session management."""
+
+    def test_clear_session_calls_checkpointer(self, tmp_path):
+        """Test clear_session calls checkpointer.delete_thread."""
+        from nanobot_deep.agent.deep_agent import DeepAgent
+        from nanobot_deep.config.schema import DeepAgentsConfig
+
+        config = self._create_mock_config(tmp_path)
+        dg_config = DeepAgentsConfig()
+
+        mock_checkpointer = MagicMock()
+        mock_checkpointer.delete_thread = MagicMock()
+
+        with patch("nanobot_deep.agent.deep_agent.DEEPAGENTS_AVAILABLE", True):
+            agent = DeepAgent(
+                workspace=tmp_path,
+                config=config,
+                checkpointer=mock_checkpointer,
+                deepagents_config=dg_config,
+            )
+
+            agent.clear_session("test-session")
+
+            mock_checkpointer.delete_thread.assert_called_once_with("test-session")
+
+    def test_clear_session_handles_no_checkpointer(self, tmp_path):
+        """Test clear_session handles missing checkpointer."""
+        from nanobot_deep.agent.deep_agent import DeepAgent
+        from nanobot_deep.config.schema import DeepAgentsConfig
+
+        config = self._create_mock_config(tmp_path)
+        dg_config = DeepAgentsConfig()
+
+        with patch("nanobot_deep.agent.deep_agent.DEEPAGENTS_AVAILABLE", True):
+            agent = DeepAgent(
+                workspace=tmp_path,
+                config=config,
+                checkpointer=None,
+                deepagents_config=dg_config,
+            )
+
+            agent.clear_session("test-session")
+
+    def test_get_history_returns_empty_without_checkpointer(self, tmp_path):
+        """Test get_history returns empty list without checkpointer."""
+        from nanobot_deep.agent.deep_agent import DeepAgent
+        from nanobot_deep.config.schema import DeepAgentsConfig
+
+        config = self._create_mock_config(tmp_path)
+        dg_config = DeepAgentsConfig()
+
+        with patch("nanobot_deep.agent.deep_agent.DEEPAGENTS_AVAILABLE", True):
+            agent = DeepAgent(
+                workspace=tmp_path,
+                config=config,
+                checkpointer=None,
+                deepagents_config=dg_config,
+            )
+
+            history = agent.get_history("test-session")
+
+            assert history == []
+
+    def _create_mock_config(self, workspace_path):
+        config = MagicMock()
+        config.workspace_path = workspace_path
+        config.agents = MagicMock()
+        config.agents.defaults = MagicMock()
+        config.agents.defaults.model = "test-model"
+        config.agents.defaults.max_tool_iterations = 10
+        config.tools = MagicMock()
+        config.tools.mcp_servers = {}
+        config.get_provider = MagicMock(return_value=None)
+        return config
+
+
+class TestDeepAgentClose:
+    """Tests for cleanup."""
+
+    @pytest.mark.asyncio
+    async def test_close_cleans_up_mcp(self, tmp_path):
+        """Test close cleans up MCP connections."""
+        from nanobot_deep.agent.deep_agent import DeepAgent
+        from nanobot_deep.config.schema import DeepAgentsConfig
+
+        config = self._create_mock_config(tmp_path)
+        dg_config = DeepAgentsConfig()
+
+        with patch("nanobot_deep.agent.deep_agent.DEEPAGENTS_AVAILABLE", True):
+            agent = DeepAgent(
+                workspace=tmp_path,
+                config=config,
+                deepagents_config=dg_config,
+            )
+
+            mock_stack = AsyncMock()
+            mock_stack.aclose = AsyncMock()
+            agent._mcp_stack = mock_stack
+
+            await agent.close()
+
+            mock_stack.aclose.assert_called_once()
+            assert agent._mcp_stack is None
+            assert agent._mcp_connected is False
+
+    @pytest.mark.asyncio
+    async def test_close_handles_exception(self, tmp_path):
+        """Test close handles exceptions during cleanup."""
+        from nanobot_deep.agent.deep_agent import DeepAgent
+        from nanobot_deep.config.schema import DeepAgentsConfig
+
+        config = self._create_mock_config(tmp_path)
+        dg_config = DeepAgentsConfig()
+
+        with patch("nanobot_deep.agent.deep_agent.DEEPAGENTS_AVAILABLE", True):
+            agent = DeepAgent(
+                workspace=tmp_path,
+                config=config,
+                deepagents_config=dg_config,
+            )
+
+            mock_stack = AsyncMock()
+            mock_stack.aclose.side_effect = Exception("Cleanup error")
+            agent._mcp_stack = mock_stack
+
+            await agent.close()
+
+            assert agent._mcp_stack is None
+
+    def _create_mock_config(self, workspace_path):
+        config = MagicMock()
+        config.workspace_path = workspace_path
+        config.agents = MagicMock()
+        config.agents.defaults = MagicMock()
+        config.agents.defaults.model = "test-model"
+        config.agents.defaults.max_tool_iterations = 10
+        config.tools = MagicMock()
+        config.tools.mcp_servers = {}
+        config.get_provider = MagicMock(return_value=None)
+        return config

--- a/tests/test_model_init.py
+++ b/tests/test_model_init.py
@@ -1,0 +1,200 @@
+"""Unit tests for model initialization with ChatLiteLLM."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+class TestModelInit:
+    """Tests for model initialization with litellm-style model names."""
+
+    def test_anthropic_model_name(self):
+        """Test anthropic model name is passed correctly."""
+        from langchain_litellm import ChatLiteLLM
+
+        model = ChatLiteLLM(
+            model="anthropic/claude-sonnet-4-5",
+            api_key="test-key",
+            max_tokens=1000,
+            temperature=0.7,
+        )
+
+        assert model.model == "anthropic/claude-sonnet-4-5"
+
+    def test_openai_model_name(self):
+        """Test openai model name is passed correctly."""
+        from langchain_litellm import ChatLiteLLM
+
+        model = ChatLiteLLM(
+            model="openai/gpt-4",
+            api_key="test-key",
+            max_tokens=1000,
+            temperature=0.7,
+        )
+
+        assert model.model == "openai/gpt-4"
+
+    def test_custom_provider_model_name(self):
+        """Test custom provider model name is passed correctly."""
+        from langchain_litellm import ChatLiteLLM
+
+        model = ChatLiteLLM(
+            model="zai/glm-4.7",
+            api_key="test-key",
+            api_base="https://api.zai.com/v1",
+            max_tokens=1000,
+            temperature=0.7,
+        )
+
+        assert model.model == "zai/glm-4.7"
+
+    def test_model_without_provider_prefix(self):
+        """Test model name without provider prefix."""
+        from langchain_litellm import ChatLiteLLM
+
+        model = ChatLiteLLM(
+            model="gpt-4",
+            api_key="test-key",
+            max_tokens=1000,
+            temperature=0.7,
+        )
+
+        assert model.model == "gpt-4"
+
+
+class TestDeepAgentModelInit:
+    """Tests for DeepAgent._init_model with various model names."""
+
+    def _create_mock_config(self, model: str = "anthropic/claude-sonnet-4-5"):
+        """Create a mock nanobot config."""
+        config = MagicMock()
+        config.agents.defaults.model = model
+        config.agents.defaults.max_tool_iterations = 10
+        config.tools.mcp_servers = {}
+
+        provider = MagicMock()
+        provider.api_key = "test-api-key"
+        provider.api_base = None
+        config.get_provider = MagicMock(return_value=provider)
+
+        return config
+
+    def _create_mock_merged_config(self, model_name: str | None = None, api_key: str | None = None):
+        """Create a mock merged DeepAgentsConfig."""
+        from nanobot_deep.config.schema import (
+            DeepAgentsConfig,
+            DeepAgentsModelConfig,
+        )
+
+        config = DeepAgentsConfig()
+        config.model = DeepAgentsModelConfig(
+            name=model_name,
+            api_key=api_key,
+            max_tokens=2000,
+            temperature=0.1,
+        )
+        return config
+
+    @patch("nanobot_deep.agent.deep_agent.merge_with_nanobot_config")
+    @patch("nanobot_deep.agent.deep_agent.DEEPAGENTS_AVAILABLE", True)
+    @patch("nanobot_deep.agent.deep_agent.create_deep_agent")
+    def test_uses_litellm_model_names(self, mock_create_agent, mock_merge):
+        """Test that model names are passed to ChatLiteLLM without parsing."""
+        from nanobot_deep.agent.deep_agent import DeepAgent
+
+        config = self._create_mock_config("anthropic/claude-sonnet-4-5")
+        merged_config = self._create_mock_merged_config()
+        mock_merge.return_value = merged_config
+
+        mock_create_agent.return_value = MagicMock()
+
+        agent = DeepAgent(
+            workspace=Path("/tmp/test"),
+            config=config,
+            checkpointer=MagicMock(),
+            deepagents_config=None,
+        )
+
+        model = agent._init_model()
+
+        assert model.model == "anthropic/claude-sonnet-4-5"
+
+    @patch("nanobot_deep.agent.deep_agent.merge_with_nanobot_config")
+    @patch("nanobot_deep.agent.deep_agent.DEEPAGENTS_AVAILABLE", True)
+    @patch("nanobot_deep.agent.deep_agent.create_deep_agent")
+    def test_custom_provider_model(self, mock_create_agent, mock_merge):
+        """Test custom provider model name is preserved."""
+        from nanobot_deep.agent.deep_agent import DeepAgent
+
+        config = self._create_mock_config("zai/glm-4.7")
+        merged_config = self._create_mock_merged_config()
+        mock_merge.return_value = merged_config
+
+        mock_create_agent.return_value = MagicMock()
+
+        agent = DeepAgent(
+            workspace=Path("/tmp/test"),
+            config=config,
+            checkpointer=MagicMock(),
+            deepagents_config=None,
+        )
+
+        model = agent._init_model()
+
+        assert model.model == "zai/glm-4.7"
+
+    @patch("nanobot_deep.agent.deep_agent.merge_with_nanobot_config")
+    @patch("nanobot_deep.agent.deep_agent.DEEPAGENTS_AVAILABLE", True)
+    @patch("nanobot_deep.agent.deep_agent.create_deep_agent")
+    def test_model_config_override(self, mock_create_agent, mock_merge):
+        """Test that deepagents config model overrides nanobot config."""
+        from nanobot_deep.agent.deep_agent import DeepAgent
+
+        config = self._create_mock_config("anthropic/claude-sonnet-4-5")
+        merged_config = self._create_mock_merged_config(model_name="openai/gpt-4o")
+        mock_merge.return_value = merged_config
+
+        mock_create_agent.return_value = MagicMock()
+
+        agent = DeepAgent(
+            workspace=Path("/tmp/test"),
+            config=config,
+            checkpointer=MagicMock(),
+            deepagents_config=None,
+        )
+
+        model = agent._init_model()
+
+        assert model.model == "openai/gpt-4o"
+
+    @patch("nanobot_deep.agent.deep_agent.merge_with_nanobot_config")
+    @patch("nanobot_deep.agent.deep_agent.DEEPAGENTS_AVAILABLE", True)
+    @patch("nanobot_deep.agent.deep_agent.create_deep_agent")
+    def test_default_model_when_none(self, mock_create_agent, mock_merge):
+        """Test default model is used when none specified."""
+        from nanobot_deep.agent.deep_agent import DeepAgent
+
+        config = MagicMock()
+        config.agents.defaults.model = None
+        config.agents.defaults.max_tool_iterations = 10
+        config.tools.mcp_servers = {}
+        config.get_provider = MagicMock(return_value=None)
+
+        merged_config = self._create_mock_merged_config(model_name=None)
+        mock_merge.return_value = merged_config
+
+        mock_create_agent.return_value = MagicMock()
+
+        agent = DeepAgent(
+            workspace=Path("/tmp/test"),
+            config=config,
+            checkpointer=MagicMock(),
+            deepagents_config=None,
+        )
+
+        model = agent._init_model()
+
+        assert model.model == "anthropic/claude-sonnet-4-5"


### PR DESCRIPTION
## Summary

- Removed `SessionCheckpointer` class that caused deadlock (fixes #4)
- Now using `AsyncSqliteSaver` from `langgraph.checkpoint.sqlite.aio` directly
- `get_session_history()` is now a utility function (works with any `BaseCheckpointSaver`)
- Added `pytest-timeout` for e2e tests with 60s per-test timeout
- Created minimal test config (`tests/e2e/deepagents.test.json`) to reduce token usage
- Updated `README.md` and `AGENTS.md` with test documentation

## Changes

| File | Change |
|------|--------|
| `checkpointer.py` | Removed class, kept utility function |
| `gateway.py` | Use `AsyncSqliteSaver` with async setup |
| `bridge.py` | Updated type hints |
| `deep_agent.py` | Use `delete_thread()`, utility function |
| `cli.py` | Async checkpointer initialization |
| `conftest.py` | Test config path parameter |
| `README.md` | Added testing section with backend comparison |
| `AGENTS.md` | Created with project guidelines |

## Test Results

- Unit tests: **82 passed**
- E2E tests: **7 passed, 3 skipped** (with `gpt-5-mini`)

## Related Issues

- Fixes #4 (deadlock during JSON migration)
- Creates #5 (migration script for legacy JSONL)
- Creates #6 (Redis vs SQLite evaluation)
- Creates #7 (cron integration evaluation)