### PR TITLE
fix: stabilize streaming output and dependency resolution

### DIFF
--- a/README.md
+++ b/README.md
@@ -411,6 +411,17 @@ pytest tests/test_deepagents_config.py -v
 CI installs dependencies using `constraints.txt` to avoid resolver conflicts between
 `nanobot-ai` and `deepagents-cli`.
 
+Current pinning includes `websockets==16.0.0`. `deepagents-cli` depends on `daytona`,
+which requires `websockets<16`, so installs that include `deepagents-cli` will fail
+until upstream relaxes the constraint. Track updates in
+https://github.com/gthieleb/nanobot-deep/issues/70.
+
+### Streaming Output Notes
+`astream_events` event `name` values are runnable names and can change when graphs or
+nodes are renamed. We capture final output based on `messages`/state output instead of
+hard-coding event names to keep streaming resilient. Details in
+https://github.com/gthieleb/nanobot-deep/issues/71.
+
 ### Code Quality
 
 ```bash

--- a/constraints.txt
+++ b/constraints.txt
@@ -1,1 +1,1 @@
-nanobot-ai<0.1.4.post4
+websockets==16.0.0

--- a/nanobot_deep/agent/deep_agent.py
+++ b/nanobot_deep/agent/deep_agent.py
@@ -540,8 +540,9 @@ Skills are available at: {self.workspace}/skills/ (read SKILL.md files as needed
                     await on_progress(hint, True)
 
             elif kind == "on_chain_end":
-                if event.get("name") == "LangGraph":
-                    final_result = event.get("data", {}).get("output", {})
+                output = event.get("data", {}).get("output")
+                if isinstance(output, dict) and "messages" in output:
+                    final_result = output
 
         return final_result or {"messages": []}
 

--- a/nanobot_deep/langgraph/bridge.py
+++ b/nanobot_deep/langgraph/bridge.py
@@ -294,8 +294,9 @@ class LangGraphBridge:
                     await on_progress(hint, True)
 
             elif kind == "on_chain_end":
-                if event.get("name") == "LangGraph":
-                    final_result = event.get("data", {}).get("output", {})
+                output = event.get("data", {}).get("output")
+                if isinstance(output, dict) and "messages" in output:
+                    final_result = output
 
         return final_result or {"messages": []}
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ authors = [
 ]
 keywords = ["ai", "agent", "langgraph", "deepagents"]
 dependencies = [
-    "nanobot-ai>=0.1.4,<0.1.4.post4",
+    "nanobot-ai>=0.1.4",
     "deepagents>=0.4.0",
     "deepagents-cli>=0.0.34",
     "langgraph>=0.2.0",
@@ -17,6 +17,7 @@ dependencies = [
     "langchain-core>=0.3.0",
     "langchain-litellm>=0.6.0",
     "langchain-mcp-adapters>=0.1.0",
+    "websockets>=16.0.0",
     "aiosqlite>=0.20.0",
 ]
 


### PR DESCRIPTION
## Summary
- capture streaming output from any chain-end result with messages
- pin websockets 16 and document the deepagents-cli/daytona conflict
- add a README note about event-name fragility in astream_events