### PR TITLE
ci: run release after version sync

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -17,8 +17,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
 
       - uses: actions/setup-python@v5
         with:
@@ -217,7 +215,7 @@ jobs:
           git add pyproject.toml nanobot_deep/__init__.py
           git commit -m "chore(release): sync version ${VERSION}"
           git push
-          echo "version_synced=false" >> $GITHUB_OUTPUT
+          echo "version_synced=true" >> $GITHUB_OUTPUT
 
   docker:
     name: Build & Push Docker Image
@@ -226,6 +224,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.ref == 'refs/heads/main' && 'main' || github.ref }}
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
@@ -276,6 +276,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          ref: ${{ github.ref == 'refs/heads/main' && 'main' || github.ref }}
 
       - name: Generate changelog
         id: changelog
@@ -299,6 +300,7 @@ jobs:
         with:
           tag_name: v${{ needs.versioning.outputs.version }}
           name: Release v${{ needs.versioning.outputs.version }}
+          target_commitish: main
           body: |
             ## Changes
             ${{ steps.changelog.outputs.changelog }}


### PR DESCRIPTION
## Summary
- keep release and docker jobs running after version sync commits
- checkout latest main when the workflow is triggered by main pushes
- tag releases against main tip to include the sync commit

## Testing
- not run (workflow change)