### PR TITLE
chore: add docker compose for gateway

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,19 @@
+services:
+  nanobot-deep:
+    image: ghcr.io/gthieleb/nanobot-deep:0.8.0
+    platform: linux/amd64
+    command: ["python", "-m", "nanobot_deep.gateway"]
+    environment:
+      NANOBOT_CONFIG_PATH: /home/nanobot/.nanobot/config.json
+      NANOBOT_WORKSPACE: /home/nanobot/.nanobot/workspace
+      NANOBOT_VALIDATE_MODEL_ON_START: "0"
+      DEEPAGENTS_CONFIG_PATH: /home/nanobot/.deepagents/config.toml
+    volumes:
+      - ${HOME}/.nanobot/workspace:/home/nanobot/.nanobot/workspace
+      - ${HOME}/.nanobot/config.json:/home/nanobot/.nanobot/config.json:ro
+      - ${HOME}/.nanobot/deepagents.json:/home/nanobot/.nanobot/deepagents.json:ro
+      - ${HOME}/.deepagents/config.toml:/home/nanobot/.deepagents/config.toml:ro
+      - ${HOME}/.config/gh/hosts.yml:/home/nanobot/.config/gh/hosts.yml:ro
+    ports:
+      - "18790:18790"
+    restart: unless-stopped


### PR DESCRIPTION
## Summary
- add docker-compose.yml for the current nanobot-deep image
- mount workspace, nanobot config, deepagents.json, deepagents config.toml, and gh cli auth
- default command runs nanobot-deep gateway

## Testing
- `docker compose -f docker-compose.yml config`
- `docker compose -f docker-compose.yml up -d` (failed on this host: exec format error; image is amd64-only)
- `docker compose -f docker-compose.yml logs --tail 80`
- `docker compose -f docker-compose.yml down`

Notes: the image is amd64-only; on arm64 hosts you need binfmt/qemu or a multi-arch image.