### PR TITLE
ci: add multi-arch docker builds

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -217,11 +217,21 @@ jobs:
           git push
           echo "version_synced=true" >> $GITHUB_OUTPUT
 
-  docker:
-    name: Build & Push Docker Image
+  docker-build:
+    name: Build & Push Docker Image (${{ matrix.arch }})
     needs: [versioning, sync_version]
     if: needs.sync_version.outputs.version_synced == 'true'
-    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - arch: amd64
+            runner: ubuntu-latest
+            platform: linux/amd64
+          - arch: arm64
+            runner: ubuntu-24.04-arm64
+            platform: linux/arm64
+    runs-on: ${{ matrix.runner }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -246,12 +256,13 @@ jobs:
         run: |
           VERSION="${{ needs.versioning.outputs.version }}"
           REPO="ghcr.io/${{ steps.repo.outputs.name }}"
-          
+          ARCH="${{ matrix.arch }}"
+
           if [[ "${{ github.ref }}" == "refs/heads/main" ]]; then
-            echo "tags=${REPO}:${VERSION},${REPO}:latest" >> $GITHUB_OUTPUT
+            echo "tags=${REPO}:${VERSION}-${ARCH},${REPO}:latest-${ARCH}" >> $GITHUB_OUTPUT
           else
             BRANCH=$(echo "${{ github.head_ref || github.ref_name }}" | sed 's/[^a-zA-Z0-9._-]/-/g')
-            echo "tags=${REPO}:${VERSION},${REPO}:${BRANCH}" >> $GITHUB_OUTPUT
+            echo "tags=${REPO}:${VERSION}-${ARCH},${REPO}:${BRANCH}-${ARCH}" >> $GITHUB_OUTPUT
           fi
 
       - name: Build and push
@@ -259,6 +270,7 @@ jobs:
         with:
           context: .
           push: true
+          platforms: ${{ matrix.platform }}
           tags: ${{ steps.docker_tags.outputs.tags }}
           labels: |
             org.opencontainers.image.source=${{ github.repositoryUrl }}
@@ -267,9 +279,46 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
+  docker-manifest:
+    name: Create Multi-Arch Docker Manifest
+    needs: [docker-build, versioning, sync_version]
+    if: needs.sync_version.outputs.version_synced == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract repository name
+        id: repo
+        run: echo "name=$(echo ${{ github.repository }} | tr '[:upper:]' '[:lower:]')" >> $GITHUB_OUTPUT
+
+      - name: Create multi-arch tags
+        run: |
+          VERSION="${{ needs.versioning.outputs.version }}"
+          REPO="ghcr.io/${{ steps.repo.outputs.name }}"
+          if [[ "${{ github.ref }}" == "refs/heads/main" ]]; then
+            docker buildx imagetools create -t "${REPO}:${VERSION}" \
+              "${REPO}:${VERSION}-amd64" "${REPO}:${VERSION}-arm64"
+            docker buildx imagetools create -t "${REPO}:latest" \
+              "${REPO}:latest-amd64" "${REPO}:latest-arm64"
+          else
+            BRANCH=$(echo "${{ github.head_ref || github.ref_name }}" | sed 's/[^a-zA-Z0-9._-]/-/g')
+            docker buildx imagetools create -t "${REPO}:${VERSION}" \
+              "${REPO}:${VERSION}-amd64" "${REPO}:${VERSION}-arm64"
+            docker buildx imagetools create -t "${REPO}:${BRANCH}" \
+              "${REPO}:${BRANCH}-amd64" "${REPO}:${BRANCH}-arm64"
+          fi
+
   release:
     name: Create GitHub Release
-    needs: [docker, versioning, sync_version]
+    needs: [docker-manifest, versioning, sync_version]
     if: github.ref == 'refs/heads/main' && needs.versioning.outputs.is_prerelease == 'false' && needs.sync_version.outputs.version_synced == 'true'
     runs-on: ubuntu-latest
     steps:
@@ -304,7 +353,7 @@ jobs:
           body: |
             ## Changes
             ${{ steps.changelog.outputs.changelog }}
-            
+
             ## Docker Image
             ```bash
             docker pull ghcr.io/${{ steps.repo.outputs.name }}:${{ needs.versioning.outputs.version }}


### PR DESCRIPTION
## Summary
- build amd64 and arm64 images on native runners
- publish per-arch tags and assemble multi-arch manifests
- keep release job dependent on the manifest step

## Testing
- not run (workflow change)