### PR TITLE
ci: split amd64 and arm64 docker builds

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -217,25 +217,15 @@ jobs:
           git push
           echo "version_synced=true" >> $GITHUB_OUTPUT
 
-  docker-build:
-    name: Build & Push Docker Image (${{ matrix.arch }})
+  docker-build-amd64:
+    name: Build & Push Docker Image (amd64)
     needs: [versioning, sync_version]
     if: needs.sync_version.outputs.version_synced == 'true'
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - arch: amd64
-            runner: ubuntu-latest
-            platform: linux/amd64
-          - arch: arm64
-            runner: ubuntu-24.04-arm64
-            platform: linux/arm64
-    runs-on: ${{ matrix.runner }}
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
         with:
-          ref: ${{ github.ref == 'refs/heads/main' && 'main' || github.ref }}
+          ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || (github.ref == 'refs/heads/main' && 'main' || github.ref) }}
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
@@ -256,7 +246,7 @@ jobs:
         run: |
           VERSION="${{ needs.versioning.outputs.version }}"
           REPO="ghcr.io/${{ steps.repo.outputs.name }}"
-          ARCH="${{ matrix.arch }}"
+          ARCH="amd64"
 
           if [[ "${{ github.ref }}" == "refs/heads/main" ]]; then
             echo "tags=${REPO}:${VERSION}-${ARCH},${REPO}:latest-${ARCH}" >> $GITHUB_OUTPUT
@@ -270,7 +260,54 @@ jobs:
         with:
           context: .
           push: true
-          platforms: ${{ matrix.platform }}
+          platforms: linux/amd64
+          tags: ${{ steps.docker_tags.outputs.tags }}
+          labels: |
+            org.opencontainers.image.source=${{ github.repositoryUrl }}
+            org.opencontainers.image.version=${{ needs.versioning.outputs.version }}
+            org.opencontainers.image.revision=${{ github.sha }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+  docker-build-arm64:
+    name: Build & Push Docker Image (arm64)
+    needs: [versioning, sync_version]
+    if: needs.sync_version.outputs.version_synced == 'true' && github.ref == 'refs/heads/main'
+    runs-on: ubuntu-24.04-arm64
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: main
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract repository name
+        id: repo
+        run: echo "name=$(echo ${{ github.repository }} | tr '[:upper:]' '[:lower:]')" >> $GITHUB_OUTPUT
+
+      - name: Generate Docker tags
+        id: docker_tags
+        run: |
+          VERSION="${{ needs.versioning.outputs.version }}"
+          REPO="ghcr.io/${{ steps.repo.outputs.name }}"
+          ARCH="arm64"
+
+          echo "tags=${REPO}:${VERSION}-${ARCH},${REPO}:latest-${ARCH}" >> $GITHUB_OUTPUT
+
+      - name: Build and push
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          push: true
+          platforms: linux/arm64
           tags: ${{ steps.docker_tags.outputs.tags }}
           labels: |
             org.opencontainers.image.source=${{ github.repositoryUrl }}
@@ -281,8 +318,8 @@ jobs:
 
   docker-manifest:
     name: Create Multi-Arch Docker Manifest
-    needs: [docker-build, versioning, sync_version]
-    if: needs.sync_version.outputs.version_synced == 'true'
+    needs: [docker-build-amd64, docker-build-arm64, versioning, sync_version]
+    if: needs.sync_version.outputs.version_synced == 'true' && github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     steps:
       - name: Set up Docker Buildx


### PR DESCRIPTION
## Summary
- build amd64 images on ubuntu-latest for PRs and branches
- build arm64 images on native ubuntu-24.04-arm64 for main only
- create multi-arch manifests only on main

## Testing
- not run (workflow change)