### PR TITLE
chore: drop compose platform pin

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,6 @@
 services:
   nanobot-deep:
     image: ghcr.io/gthieleb/nanobot-deep:0.8.0
-    platform: linux/amd64
     command: ["python", "-m", "nanobot_deep.gateway"]
     environment:
       NANOBOT_CONFIG_PATH: /home/nanobot/.nanobot/config.json


### PR DESCRIPTION
## Summary
- remove `platform: linux/amd64` from docker-compose now that arm64 images are published

## Testing
- `docker compose -f docker-compose.yml config`