### PR TITLE
fix: run gateway via cli module in compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 services:
   nanobot-deep:
     image: ghcr.io/gthieleb/nanobot-deep:latest
-    command: ["python", "-m", "nanobot_deep.gateway"]
+    command: ["python", "-m", "nanobot_deep.cli", "gateway"]
     environment:
       NANOBOT_CONFIG_PATH: /home/nanobot/.nanobot/config.json
       NANOBOT_WORKSPACE: /home/nanobot/.nanobot/workspace


### PR DESCRIPTION
## Summary
- run the gateway via the CLI module in docker-compose to avoid a no-op module

## Testing
- manual smoke test on ubuntu-4gb-hel1-1: `docker compose up -d --pull always`