### PR TITLE
Fix docker-compose port binding to localhost

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -335,6 +335,11 @@ docker compose -f docker-compose.yml -f docker-compose.langfuse.yml up -d
 # Access Langfuse UI at http://localhost:3000
 ```
 
+### Docker Compose
+
+When editing docker-compose files, ensure ports are bound to localhost unless you explicitly need LAN/CI exposure.
+Use `127.0.0.1:PORT:PORT` instead of `PORT:PORT`.
+
 ### OTEL Telemetry
 
 OpenTelemetry is supported via environment variables:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,5 +14,5 @@ services:
       - ${HOME}/.deepagents/config.toml:/home/nanobot/.deepagents/config.toml:ro
       - ${HOME}/.config/gh/hosts.yml:/home/nanobot/.config/gh/hosts.yml:ro
     ports:
-      - "18790:18790"
+      - "127.0.0.1:18790:18790"
     restart: unless-stopped


### PR DESCRIPTION
## Summary
- bind the gateway port to localhost in docker-compose
- document localhost-only port binding guidance in AGENTS

## Testing
- not run (not requested)