### PR TITLE
chore(ci): add workflow dispatch trigger

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -5,6 +5,7 @@ on:
     branches: [main, 'feature/**', 'fix/**']
   pull_request:
     branches: [main]
+  workflow_dispatch:
 
 permissions:
   contents: write


### PR DESCRIPTION
## Summary
- allow manual runs of the CI/CD pipeline via workflow_dispatch

## Testing
- not run (workflow configuration change)