### PR TITLE
fix(cli): consolidate config on --config flag, remove NANOBOT_CONFIG_PATH

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,15 +4,6 @@ Configuration and testing guide for AI agents working on nanobot-deep.
 
 ## Environment Variables
 
-### NANOBOT_CONFIG_PATH
-Path to the nanobot configuration file. Used by tests to load model and API key.
-
-```bash
-export NANOBOT_CONFIG_PATH=~/.nanobot/config.json
-pytest tests/e2e/ -m live -v
-```
-
-Default: `~/.nanobot/config.json`
 
 ### DEEPAGENTS_CONFIG_PATH
 Path to the DeepAgents CLI model config file (config.toml). Overrides the default.
@@ -69,7 +60,7 @@ pytest tests/ -v
 ### E2E Tests (Live LLM)
 ```bash
 # Recommended: Use existing config
-export NANOBOT_CONFIG_PATH=~/.nanobot/config.json
+NANOBOT_TEST_CONFIG=~/.nanobot/config.json
 pytest tests/e2e/ -m live -v
 
 # Or override model

--- a/Dockerfile
+++ b/Dockerfile
@@ -97,7 +97,6 @@ ENV PATH="/app/.venv/bin:$PATH" \
     PYTHONUNBUFFERED=1 \
     HOME=/app \
     XDG_CONFIG_HOME=/app/.config \
-    NANOBOT_CONFIG_PATH=/app/.nanobot/config.json \
     DEEPAGENTS_CONFIG_PATH=/app/.deepagents/config.toml \
     NANOBOT_WORKSPACE=/app/.nanobot/workspace
 

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -4,13 +4,16 @@ services:
       context: .
       dockerfile: Dockerfile
     image: nanobot-deep:dev
+    command:
+    - gateway
+    - --config
+    - /app/.nanobot/config.json
     volumes:
     - ./nanobot_deep:/app/nanobot_deep
     - ./templates:/app/templates
     - ${HOME}/.nanobot:/app/.nanobot
     - ${HOME}/.deepagents/config.toml:/app/.deepagents/config.toml:ro
     environment:
-      NANOBOT_CONFIG_PATH: /app/.nanobot/config.json
       NANOBOT_WORKSPACE: /app/.nanobot/workspace
       DEEPAGENTS_CONFIG_PATH: /app/.deepagents/config.toml
       XDG_CONFIG_HOME: /app/.config

--- a/docker-compose.yml.example
+++ b/docker-compose.yml.example
@@ -4,8 +4,9 @@ services:
     user: 1000:1000
     command:
     - gateway
+    - --config
+    - /app/.nanobot/config-nanobot-deep.json
     environment:
-      NANOBOT_CONFIG_PATH: /app/.nanobot/config-nanobot-deep.json
       NANOBOT_WORKSPACE: /app/.nanobot/workspace
       NANOBOT_VALIDATE_MODEL_ON_START: '0'
       DEEPAGENTS_CONFIG_PATH: /app/.deepagents/config.toml

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -2,7 +2,7 @@
 
 Usage:
     # Option 1: Use existing nanobot config for channels/workspace
-    export NANOBOT_CONFIG_PATH=~/.nanobot/config.json
+    NANOBOT_TEST_CONFIG=~/.nanobot/config.json
     # Optional: Override DeepAgents config.toml path
     export DEEPAGENTS_CONFIG_PATH=~/.deepagents/config.toml
     # Optional: Use minimal deepagents test config
@@ -50,12 +50,12 @@ def pytest_configure(config):
 def nanobot_test_config() -> "Config":
     """Load nanobot config for tests.
 
-    Uses NANOBOT_TEST_CONFIG or NANOBOT_CONFIG_PATH if set, otherwise default
+    Uses NANOBOT_TEST_CONFIG if set, otherwise default
     ~/.nanobot/config.json.
     """
     from nanobot.config.loader import load_config
 
-    config_path = os.environ.get("NANOBOT_TEST_CONFIG") or os.environ.get("NANOBOT_CONFIG_PATH")
+    config_path = os.environ.get("NANOBOT_TEST_CONFIG")
     if config_path:
         config_path = Path(config_path)
     else:
@@ -64,7 +64,7 @@ def nanobot_test_config() -> "Config":
     if not config_path.exists():
         pytest.skip(
             f"Config not found at {config_path}. Set NANOBOT_TEST_CONFIG or "
-            "NANOBOT_CONFIG_PATH, or create a default config."
+            "or create a default config."
         )
 
     return load_config(config_path)

--- a/tests/e2e/test_cli_agent_live.py
+++ b/tests/e2e/test_cli_agent_live.py
@@ -13,7 +13,7 @@ pytestmark = pytest.mark.live
 
 
 def _resolve_config_path() -> Path:
-    config_path = os.environ.get("NANOBOT_TEST_CONFIG") or os.environ.get("NANOBOT_CONFIG_PATH")
+    config_path = os.environ.get("NANOBOT_TEST_CONFIG")
     if config_path:
         return Path(config_path).expanduser().resolve()
     return Path.home() / ".nanobot" / "config.json"
@@ -24,7 +24,7 @@ class TestCliAgent:
         config_path = _resolve_config_path()
         if not config_path.exists():
             pytest.skip(
-                f"Config not found at {config_path}. Set NANOBOT_TEST_CONFIG or NANOBOT_CONFIG_PATH."
+                f"Config not found at {config_path}. Set NANOBOT_TEST_CONFIG."
             )
 
         workspace = tmp_path / "workspace"

--- a/tests/test_cli_config.py
+++ b/tests/test_cli_config.py
@@ -1,0 +1,62 @@
+"""Tests for CLI config loading behavior.
+
+Validates that _load_config() correctly resolves the config file path.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+import nanobot.config.loader as config_loader
+
+from nanobot_deep.cli import _load_config
+
+
+@pytest.mark.xfail(
+    reason="NANOBOT_CONFIG_PATH env var is not read by _load_config(). "
+    "Config is passed via --config CLI flag instead. See PR #138.",
+    strict=True,
+)
+def test_load_config_uses_nanobot_config_path_env(monkeypatch, tmp_path):
+    """_load_config() should respect NANOBOT_CONFIG_PATH when no --config is given.
+
+    This test documents that the env var is NOT read — it is expected to fail (xfail).
+    The intended fix is to always pass --config via Docker command instead of relying
+    on the environment variable.
+    """
+    env_config_path = tmp_path / "config-nanobot-deep.json"
+    default_config_path = tmp_path / "config.json"
+
+    env_config_path.write_text(
+        json.dumps(
+            {
+                "agents": {"defaults": {"workspace": str(tmp_path / "env-ws")}},
+                "channels": {"telegram": {"enabled": True, "token": "ENV_TOKEN_STOLZIBOT"}},
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    default_config_path.write_text(
+        json.dumps(
+            {
+                "agents": {"defaults": {"workspace": str(tmp_path / "default-ws")}},
+                "channels": {"telegram": {"enabled": True, "token": "DEFAULT_TOKEN_EAST79BOT"}},
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    monkeypatch.setenv("NANOBOT_CONFIG_PATH", str(env_config_path))
+    monkeypatch.setattr(config_loader, "_current_config_path", None, raising=False)
+    monkeypatch.setattr(config_loader, "get_config_path", lambda: default_config_path)
+
+    loaded = _load_config()
+
+    assert loaded.agents.defaults.workspace == str(tmp_path / "env-ws"), (
+        f"Expected env config workspace '{tmp_path / 'env-ws'}', "
+        f"got '{loaded.agents.defaults.workspace}'. "
+        "_load_config() ignored NANOBOT_CONFIG_PATH and used the default path."
+    )


### PR DESCRIPTION
## Summary

`NANOBOT_CONFIG_PATH` env var was set in Dockerfile and docker-compose but **never read by `_load_config()` in cli.py**. This caused Docker containers to silently load the wrong config file — and the wrong Telegram bot token, creating a polling conflict between two bot instances.

## Root Cause

`_load_config()` only accepts config path via the `--config` CLI argument. When no `--config` is passed (Docker startup), it falls back to the hardcoded default `~/.nanobot/config.json`. The env var was dead code.

## Changes

- **Dockerfile**: Removed `NANOBOT_CONFIG_PATH` from `ENV` block
- **docker-compose.yml.example**: Uses `command: [gateway, --config, /app/.nanobot/config-nanobot-deep.json]`
- **docker-compose.dev.yml**: Uses `command: [gateway, --config, /app/.nanobot/config.json]`
- **tests/test_cli_config.py**: Failing test proving the env var is ignored
- **tests/e2e/conftest.py**: Standardized on `NANOBOT_TEST_CONFIG`
- **tests/e2e/test_cli_agent_live.py**: Same
- **AGENTS.md**: Removed `NANOBOT_CONFIG_PATH` docs, updated to `NANOBOT_TEST_CONFIG`

## Note

The new test in `test_cli_config.py` is **intentionally failing** — it proves the bug exists. The behavioral fix (making `_load_config()` use `--config` from Docker command) is already working via the compose `command:` change.

Closes #128