### PR TITLE
fix(config): use api_key_env for provider credentials instead of params.api_key

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,7 @@
+# Provider API keys for deepagents-cli.
+# Set these or export them in your shell before running docker compose.
+# See README.md "Provider Credentials in Docker" for details.
+
+LITELLM_API_KEY=
+# ANTHROPIC_API_KEY=
+# OPENAI_API_KEY=

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -47,9 +47,11 @@ Primary tracking issues:
 
 ## Known Upstream Issues (deepagents-cli)
 
-- `create_model()` early credential check ignores `params.api_key` from `config.toml` ([langchain-ai/deepagents#2724](https://github.com/langchain-ai/deepagents/issues/2724)).
-  Workaround: set `LITELLM_API_KEY` (or the relevant provider env var) explicitly in Docker environment.
-  Affects any provider using `params.api_key` instead of `api_key_env` or env vars.
+- `create_model()` early credential check ignores `params.api_key` from `config.toml`
+  ([langchain-ai/deepagents#2724](https://github.com/langchain-ai/deepagents/issues/2724),
+  docs updated in [#2770](https://github.com/langchain-ai/deepagents/pull/2770)).
+  **Fix:** Use `api_key_env = "LITELLM_API_KEY"` in the provider config section (not in `params`).
+  Set the actual key via env var or `.env` file. Docker Compose files include `env_file` reference.
 - When filing issues on `langchain-ai/deepagents`, **you must use an issue template** or the bot auto-closes immediately.
   Use: `gh issue create --repo langchain-ai/deepagents --body-file` with the bug-report template checklist included.
 
@@ -92,7 +94,8 @@ Keep entries concise and include:
 When using the DeepAgents `litellm` provider in `~/.deepagents/config.toml`:
 
 - For z.ai, use model names with the `zai/` prefix (for example `litellm:zai/glm-4.5`).
-- A single provider-level `api_key` under `[models.providers.litellm.params]` works as a global default.
+- **Do not set `api_key` in `params`** — the early credential check runs before `params` are read ([#2724](https://github.com/langchain-ai/deepagents/issues/2724)). Use `api_key_env` at the provider level instead.
+- Correct pattern: `api_key_env = "LITELLM_API_KEY"` in the provider section, then set the key via env var or `.env` file.
 - You are not limited to one key overall: for multiple providers you can use provider-specific environment variables (for example `OPENAI_API_KEY`, `ANTHROPIC_API_KEY`, `ZAI_API_KEY`) and/or per-model overrides under `params`.
 - A LiteLLM proxy is optional and only needed when you want centralized routing/policies/logging; it is not required just to use multiple provider keys.
 
@@ -162,17 +165,26 @@ See [Testing](../../README.md#telegram-e2e-tests) section in main README.md for 
 The model is configured in `~/.deepagents/config.toml`:
 
 ```toml
+[models]
+default = "litellm:zai/glm-4.5"
+
 [models.providers.litellm]
 enabled = true
 models = ["zai/glm-4.5", "zai/glm-4.5-air"]
+api_key_env = "LITELLM_API_KEY"
 
 [models.providers.litellm.params]
-api_key = "************"
 api_base = "https://api.z.ai/api/paas/v4"
 temperature = 0.1
 
-[models.providers.anthropic.params]
-api_key = "******************"
+[models.providers.anthropic]
+api_key_env = "ANTHROPIC_API_KEY"
+```
+
+Set the actual API key via environment variable or `.env` file:
+
+```bash
+export LITELLM_API_KEY="sk-..."
 ```
 
 ## Langfuse Observability

--- a/README.md
+++ b/README.md
@@ -33,6 +33,21 @@ docker compose -f docker-compose.yml -f docker-compose.dev.yml up -d --build
 Code changes in `./nanobot_deep` and `./templates` are picked up on restart.
 If you change dependencies, rebuild the image.
 
+### Provider Credentials in Docker
+
+Provider API keys must be available as environment variables — they cannot be read from `params.api_key` in `config.toml` due to an upstream limitation ([deepagents-cli#2724](https://github.com/langchain-ai/deepagents/issues/2724)). Use `api_key_env` in the provider config and pass the key via Docker environment.
+
+Create a `.env` file next to your `docker-compose.yml`:
+
+```bash
+# .env
+LITELLM_API_KEY=sk-your-key-here
+# ANTHROPIC_API_KEY=sk-...
+# OPENAI_API_KEY=sk-...
+```
+
+Docker Compose automatically reads `.env` files for variable substitution (`${LITELLM_API_KEY}`).
+
 **Config file permissions**: If using Docker, ensure config files in `~/.nanobot/`
 are readable by the container. Add the container user to your group or set
 files to world-readable.
@@ -413,8 +428,30 @@ These notes apply to `~/.deepagents/config.toml` model/provider settings.
 When using DeepAgents with the `litellm` provider in `~/.deepagents/config.toml`:
 
 - Use `zai/` model names for z.ai (for example `litellm:zai/glm-4.5`).
-- A provider-level `api_key` under `[models.providers.litellm.params]` can be used as a global default key.
-- You are not limited to one key overall. For multi-provider setups, use provider-specific env vars (for example `OPENAI_API_KEY`, `ANTHROPIC_API_KEY`, `ZAI_API_KEY`) and/or per-model `params` overrides.
+- **Do not set `api_key` in `params`** — the deepagents-cli early credential check runs before `params` are read, so the key is never seen ([langchain-ai/deepagents#2724](https://github.com/langchain-ai/deepagents/issues/2724)). Use `api_key_env` at the provider level instead.
+- Correct config layout:
+
+```toml
+[models]
+default = "litellm:zai/glm-4.5"
+
+[models.providers.litellm]
+enabled = true
+models = ["zai/glm-4.5", "zai/glm-4.5-air"]
+api_key_env = "LITELLM_API_KEY"
+
+[models.providers.litellm.params]
+api_base = "https://api.z.ai/api/paas/v4"
+temperature = 0.1
+```
+
+Then set the actual key in your environment or `.env` file:
+
+```bash
+export LITELLM_API_KEY="sk-your-key-here"
+```
+
+- You are not limited to one key overall. For multi-provider setups, use provider-specific env vars (for example `OPENAI_API_KEY`, `ANTHROPIC_API_KEY`, `ZAI_API_KEY`) and/or per-model overrides under `params`.
 - A LiteLLM proxy is optional. Use it for centralized routing/policies/logging, not because multiple keys are otherwise impossible.
 
 ## Langfuse Observability

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -13,9 +13,13 @@ services:
     - ./templates:/app/templates
     - ${HOME}/.nanobot:/app/.nanobot
     - ${HOME}/.deepagents/config.toml:/app/.deepagents/config.toml:ro
+    env_file:
+    - path: .env
+      required: false
     environment:
       NANOBOT_WORKSPACE: /app/.nanobot/workspace
       DEEPAGENTS_CONFIG_PATH: /app/.deepagents/config.toml
       XDG_CONFIG_HOME: /app/.config
+      LITELLM_API_KEY: ${LITELLM_API_KEY:-}
     ports:
     - 127.0.0.1:18790:18790

--- a/docker-compose.yml.example
+++ b/docker-compose.yml.example
@@ -6,11 +6,15 @@ services:
     - gateway
     - --config
     - /app/.nanobot/config-nanobot-deep.json
+    env_file:
+    - path: .env
+      required: false
     environment:
       NANOBOT_WORKSPACE: /app/.nanobot/workspace
       NANOBOT_VALIDATE_MODEL_ON_START: '0'
       DEEPAGENTS_CONFIG_PATH: /app/.deepagents/config.toml
       XDG_CONFIG_HOME: /app/.config
+      LITELLM_API_KEY: ${LITELLM_API_KEY:-}
     volumes:
     - ${HOME}/.nanobot:/app/.nanobot
     - ${HOME}/.deepagents/config.toml:/app/.deepagents/config.toml:ro


### PR DESCRIPTION
## Summary

Provider API keys in `~/.deepagents/config.toml` must use `api_key_env` (pointing to an environment variable name) rather than `api_key` in the `params` section. The deepagents-cli early credential check runs **before** `params` are loaded, so `params.api_key` is never seen and model creation always fails with `ModelConfigError`.

This is now documented upstream ([deepagents-cli#2770](https://github.com/langchain-ai/deepagents/pull/2770)) and the original issue was closed as "working as intended" ([deepagents-cli#2724](https://github.com/langchain-ai/deepagents/issues/2724)).

## Changes

- **README.md**: Fix LiteLLM Notes — remove incorrect `params.api_key` guidance, add correct `api_key_env` pattern with example config. Add "Provider Credentials in Docker" section with `.env` file instructions.
- **AGENTS.md**: Update Known Upstream Issues with fix (not just workaround), update LiteLLM Provider Notes, update Model Configuration example to show `api_key_env`.
- **`docker-compose.yml.example`**: Add `env_file` reference (`.env`, optional) and `LITELLM_API_KEY` env var passthrough.
- **`docker-compose.dev.yml`**: Same pattern as example.
- **`.env.example`**: New file with provider API key placeholders.

## Migration

Users currently setting `api_key` in `[models.providers.litellm.params]` need to:

1. Move the key to an environment variable (e.g. `export LITELLM_API_KEY=sk-...`)
2. Add `api_key_env = "LITELLM_API_KEY"` to the provider section in `config.toml`
3. Remove `api_key` from `params`

Before:
```toml
[models.providers.litellm.params]
api_key = "sk-your-key"
```

After:
```toml
[models.providers.litellm]
api_key_env = "LITELLM_API_KEY"
```

## References

- [langchain-ai/deepagents#2724](https://github.com/langchain-ai/deepagents/issues/2724) — Original bug report
- [langchain-ai/deepagents#2770](https://github.com/langchain-ai/deepagents/pull/2770) — Upstream docs update