### PR TITLE
feat(bridge): pass msg.metadata for HITL/Langfuse routing

### DIFF
--- a/nanobot_deep/agent/deep_agent.py
+++ b/nanobot_deep/agent/deep_agent.py
@@ -391,7 +391,9 @@ class DeepAgent:
                 "chat_id": msg.chat_id,
                 "user_id": msg.sender_id,
                 "is_group": msg.metadata.get("is_group", False) if msg.metadata else False,
-                "message_thread_id": msg.metadata.get("message_thread_id") if msg.metadata else None,
+                "message_thread_id": msg.metadata.get("message_thread_id")
+                if msg.metadata
+                else None,
             },
         }
 
@@ -484,7 +486,9 @@ class DeepAgent:
                     tool_args=tool_args,
                     description=description,
                     allowed_decisions=allowed_decisions,
-                    message_thread_id=msg.metadata.get("message_thread_id") if msg.metadata else None,
+                    message_thread_id=msg.metadata.get("message_thread_id")
+                    if msg.metadata
+                    else None,
                     timeout=self.dg_config.interrupt_on.auto_reject_timeout
                     if hasattr(self.dg_config, "interrupt_on")
                     else 60.0,

--- a/nanobot_deep/agent/deep_agent.py
+++ b/nanobot_deep/agent/deep_agent.py
@@ -386,6 +386,13 @@ class DeepAgent:
             "configurable": {
                 "thread_id": msg.session_key,
             },
+            "metadata": {
+                "channel": msg.channel,
+                "chat_id": msg.chat_id,
+                "user_id": msg.sender_id,
+                "is_group": msg.metadata.get("is_group", False) if msg.metadata else False,
+                "message_thread_id": msg.metadata.get("message_thread_id") if msg.metadata else None,
+            },
         }
 
         langfuse_handler = self._get_langfuse_handler()
@@ -477,6 +484,7 @@ class DeepAgent:
                     tool_args=tool_args,
                     description=description,
                     allowed_decisions=allowed_decisions,
+                    message_thread_id=msg.metadata.get("message_thread_id") if msg.metadata else None,
                     timeout=self.dg_config.interrupt_on.auto_reject_timeout
                     if hasattr(self.dg_config, "interrupt_on")
                     else 60.0,

--- a/nanobot_deep/channels/telegram.py
+++ b/nanobot_deep/channels/telegram.py
@@ -221,6 +221,7 @@ class CustomTelegramChannel(TelegramChannel):
                 text=message_text,
                 parse_mode="HTML",
                 reply_markup=keyboard,
+                message_thread_id=interrupt.message_thread_id,
             )
             REGISTRY.set_message_id(interrupt.tool_call_id, message.message_id)
             logger.info(

--- a/nanobot_deep/langgraph/interrupt_registry.py
+++ b/nanobot_deep/langgraph/interrupt_registry.py
@@ -29,6 +29,7 @@ class PendingInterrupt:
     description: str
     allowed_decisions: list[str]
     message_id: int | None = None
+    message_thread_id: str | None = None
     timeout: float = 60.0
     created_at: float = field(default_factory=time.time)
 


### PR DESCRIPTION
## Summary

Pass Telegram message metadata (user_id, chat_id, is_group, message_thread_id) through to LangGraph config.metadata for proper HITL routing and Langfuse observability.

### Changes

- **deep_agent.py**: 
  - `config['metadata']` with channel/chat_id/user_id/is_group/message_thread_id
  - `PendingInterrupt` creation includes `message_thread_id`
- **interrupt_registry.py**: `PendingInterrupt` has new `message_thread_id` field
- **telegram.py**: `send_message` passes `message_thread_id` for thread routing

### Why

When a HITL interrupt occurs in a Telegram group with topics, the approval/rejection message needs to go to the correct thread. This ensures:
1. Interrupt responses route to the correct thread/topic
2. Langfuse traces include proper metadata for filtering by chat/user

### Testing

- `pytest tests/ -q`: 210 passed, 110 skipped, 1 xfailed