### PR TITLE
chore(ci): opt into Node.js 24 to fix deprecation warnings

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -7,6 +7,9 @@ on:
     branches: [main]
   workflow_dispatch:
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 permissions:
   contents: write
   packages: write


### PR DESCRIPTION
## Summary
- Add FORCE_JAVASCRIPT_ACTIONS_TO_NODE24=true to fix Node.js 20 deprecation warnings