### PR TITLE
feat(bridge): add Telegram metadata as SystemMessage to LLM context

### DIFF
--- a/nanobot_deep/langgraph/bridge.py
+++ b/nanobot_deep/langgraph/bridge.py
@@ -75,6 +75,22 @@ def translate_inbound_to_state(
             elif role == "system":
                 messages.append(SystemMessage(content=str(content)))
 
+    if msg.metadata:
+        meta_parts = [
+            f"channel={msg.channel}",
+            f"chat_id={msg.chat_id}",
+            f"user_id={msg.metadata.get('user_id', 'unknown')}",
+        ]
+        if msg.metadata.get("message_thread_id"):
+            meta_parts.append(f"thread_id={msg.metadata['message_thread_id']}")
+        if msg.metadata.get("is_group"):
+            meta_parts.append(f"is_group={msg.metadata['is_group']}")
+        if msg.metadata.get("is_forum"):
+            meta_parts.append(f"is_forum={msg.metadata['is_forum']}")
+
+        meta_msg = "[Channel] " + ", ".join(meta_parts)
+        messages.append(SystemMessage(content=meta_msg))
+
     if msg.media:
         content_blocks: list[dict[str, Any]] = [{"type": "text", "text": msg.content}]
         for media in msg.media:

--- a/tests/test_bridge.py
+++ b/tests/test_bridge.py
@@ -100,6 +100,39 @@ class TestTranslateInboundToState:
         assert "manager" in state["messages"][0].content
         assert "Do you agree with this proposal?" in state["messages"][0].content
 
+    def test_message_with_metadata_system_message(self):
+        """Test message with metadata adds SystemMessage with channel context."""
+        from nanobot.bus.events import InboundMessage
+
+        from nanobot_deep.langgraph.bridge import translate_inbound_to_state
+
+        msg = InboundMessage(
+            channel="telegram",
+            sender_id="user123",
+            chat_id="chat456",
+            content="Hello in thread!",
+            metadata={
+                "user_id": 12345,
+                "username": "alice",
+                "message_thread_id": 789,
+                "is_group": True,
+                "is_forum": True,
+            },
+        )
+
+        state = translate_inbound_to_state(msg)
+
+        system_messages = [m for m in state["messages"] if isinstance(m, SystemMessage)]
+        assert len(system_messages) == 1
+
+        meta_content = system_messages[0].content
+        assert "[Channel]" in meta_content
+        assert "channel=telegram" in meta_content
+        assert "chat_id=chat456" in meta_content
+        assert "thread_id=789" in meta_content
+        assert "is_group=True" in meta_content
+        assert "is_forum=True" in meta_content
+
 
 class TestTranslateResultToOutbound:
     """Tests for translate_result_to_outbound function."""


### PR DESCRIPTION
## Summary

The LLM now receives Telegram channel metadata (chat_id, thread_id, user_id, is_group, is_forum) as a SystemMessage before each user message. This allows the agent to know which Telegram thread/group it's responding in.

## Problem

The agent couldn't see Thread ID or group metadata when responding to Telegram messages, even though this data was captured in the channel's metadata.

## Changes

- nanobot_deep/langgraph/bridge.py: Add SystemMessage with metadata before HumanMessage
- tests/test_bridge.py: Add test for metadata SystemMessage

## Testing

- pytest tests/test_bridge.py: 22 passed
- pytest tests/: 214 passed

## Verification

After this PR, when the agent receives a Telegram message in a thread, it will see:
```
[Channel] channel=telegram, chat_id=123, thread_id=456, is_group=True, is_forum=True
User: Hallo from Thread 456!
```