### PR TITLE
fix(ci): version on PR merges to main

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -150,7 +150,7 @@ jobs:
       - name: Check if prerelease
         id: check_prerelease
         run: |
-          if [[ "${{ github.ref }}" == "refs/heads/main" ]]; then
+          if [[ "${{ github.ref }}" == "refs/heads/main" ]] || [[ "${{ github.base_ref }}" == "main" ]]; then
             echo "is_prerelease=false" >> $GITHUB_OUTPUT
           else
             echo "is_prerelease=true" >> $GITHUB_OUTPUT
@@ -329,7 +329,7 @@ jobs:
   docker-manifest:
     name: Create Multi-Arch Docker Manifest
     needs: [docker-build-amd64, docker-build-arm64, versioning, sync_version]
-    if: github.ref == 'refs/heads/main' && needs.sync_version.outputs.version_synced == 'true'
+    if: (github.ref == 'refs/heads/main' || github.base_ref == 'main') && needs.sync_version.outputs.version_synced == 'true'
     runs-on: ubuntu-latest
     steps:
       - name: Set up Docker Buildx
@@ -366,7 +366,7 @@ jobs:
   update-docker-compose:
     name: Update docker-compose.yml.example
     needs: [docker-manifest, versioning, sync_version]
-    if: github.ref == 'refs/heads/main' && needs.versioning.outputs.is_prerelease == 'false' && needs.sync_version.outputs.version_synced == 'true'
+    if: (github.ref == 'refs/heads/main' || github.base_ref == 'main') && needs.versioning.outputs.is_prerelease == 'false' && needs.sync_version.outputs.version_synced == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -412,7 +412,7 @@ jobs:
   release:
     name: Create GitHub Release
     needs: [update-docker-compose, versioning]
-    if: github.ref == 'refs/heads/main' && needs.versioning.outputs.is_prerelease == 'false' && needs.sync_version.outputs.version_synced == 'true'
+    if: (github.ref == 'refs/heads/main' || github.base_ref == 'main') && needs.versioning.outputs.is_prerelease == 'false' && needs.sync_version.outputs.version_synced == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
## Summary

Fix CI versioning to properly tag releases and update versions when PRs are merged to main.

## Problem

When a PR is merged to main:
- `github.ref` is `refs/pull/XXX/merge` (not main)
- This caused `is_prerelease=true` to be set
- Version tagging and release creation was skipped!

The CI correctly calculated version `0.15.0` but never tagged/released it.

## Changes

1. **is_prerelease check**: Added `github.base_ref == "main"` condition
2. **Release/Sync conditions**: Extended all conditions to trigger on PRs to main

## Before
```yaml
if: github.ref == 'refs/heads/main' && ...
```

## After
```yaml
if: (github.ref == 'refs/heads/main' || github.base_ref == 'main') && ...
```

## Testing

- [ ] PR created to test this fix
- [ ] Verify version is tagged correctly
- [ ] Verify release is created