### PR TITLE
feat(bridge): Hermes-style session key routing + extended metadata

### DIFF
--- a/nanobot_deep/langgraph/bridge.py
+++ b/nanobot_deep/langgraph/bridge.py
@@ -22,6 +22,21 @@ if TYPE_CHECKING:
     from nanobot.bus.events import InboundMessage, OutboundMessage
 
 
+def build_session_key(msg: "InboundMessage") -> str:
+    """Build Hermes-style session keys for Telegram conversations."""
+    metadata = msg.metadata or {}
+    chat_id = msg.chat_id
+    thread_id = metadata.get("message_thread_id")
+
+    if metadata.get("is_group") and metadata.get("is_forum") and thread_id is not None:
+        return f"nanobot:telegram:topic:{chat_id}:{thread_id}"
+
+    if metadata.get("is_group"):
+        return f"nanobot:telegram:group:{chat_id}"
+
+    return f"nanobot:telegram:dm:{chat_id}"
+
+
 def translate_inbound_to_state(
     msg: "InboundMessage",
     history: list[dict] | None = None,

--- a/nanobot_deep/langgraph/bridge.py
+++ b/nanobot_deep/langgraph/bridge.py
@@ -55,6 +55,19 @@ def translate_inbound_to_state(
         LangGraph state dict with 'messages' key
     """
     messages = []
+    metadata = msg.metadata or {}
+
+    def _format_location(value: Any) -> str | None:
+        if isinstance(value, (list, tuple)) and len(value) >= 2:
+            return f"{value[0]},{value[1]}"
+        if isinstance(value, dict):
+            lat = value.get("lat", value.get("latitude"))
+            lon = value.get("lon", value.get("lng", value.get("longitude")))
+            if lat is not None and lon is not None:
+                return f"{lat},{lon}"
+        if value is not None:
+            return str(value)
+        return None
 
     if system_prompt:
         messages.append(SystemMessage(content=system_prompt))
@@ -90,20 +103,28 @@ def translate_inbound_to_state(
             elif role == "system":
                 messages.append(SystemMessage(content=str(content)))
 
-    if msg.metadata:
+    if metadata:
+        timestamp = metadata.get("timestamp") or metadata.get("date")
+        location_str = _format_location(metadata.get("location"))
+        thread_id = metadata.get("thread_id")
+        if thread_id is None:
+            thread_id = metadata.get("message_thread_id")
+
         meta_parts = [
             f"channel={msg.channel}",
             f"chat_id={msg.chat_id}",
             f"user_id={msg.metadata.get('user_id', 'unknown')}",
+            f"timestamp={timestamp}" if timestamp is not None else None,
+            f"location={location_str}" if location_str else None,
         ]
-        if msg.metadata.get("message_thread_id"):
-            meta_parts.append(f"thread_id={msg.metadata['message_thread_id']}")
-        if msg.metadata.get("is_group"):
-            meta_parts.append(f"is_group={msg.metadata['is_group']}")
-        if msg.metadata.get("is_forum"):
-            meta_parts.append(f"is_forum={msg.metadata['is_forum']}")
+        if thread_id is not None:
+            meta_parts.append(f"thread_id={thread_id}")
+        if metadata.get("is_group"):
+            meta_parts.append(f"is_group={metadata['is_group']}")
+        if metadata.get("is_forum"):
+            meta_parts.append(f"is_forum={metadata['is_forum']}")
 
-        meta_msg = "[Channel] " + ", ".join(meta_parts)
+        meta_msg = "[Channel] " + ", ".join(part for part in meta_parts if part)
         messages.append(SystemMessage(content=meta_msg))
 
     if msg.media:
@@ -120,7 +141,18 @@ def translate_inbound_to_state(
     else:
         messages.append(HumanMessage(content=msg.content))
 
-    return {"messages": messages}
+    return {
+        "messages": messages,
+        "metadata": {
+            "channel": msg.channel,
+            "chat_id": msg.chat_id,
+            "thread_id": metadata.get("thread_id")
+            if metadata.get("thread_id") is not None
+            else metadata.get("message_thread_id"),
+            "timestamp": metadata.get("timestamp") or metadata.get("date"),
+            "location": _format_location(metadata.get("location")),
+        },
+    }
 
 
 def extract_reply_context(msg: "InboundMessage") -> dict[str, Any] | None:

--- a/tests/test_bridge.py
+++ b/tests/test_bridge.py
@@ -5,6 +5,52 @@ from __future__ import annotations
 from langchain_core.messages import AIMessage, HumanMessage, SystemMessage, ToolMessage
 
 
+class TestBuildSessionKey:
+    def test_build_session_key_dm(self):
+        from nanobot.bus.events import InboundMessage
+
+        from nanobot_deep.langgraph.bridge import build_session_key
+
+        msg = InboundMessage(
+            channel="telegram",
+            sender_id="user123",
+            chat_id="123",
+            content="Hello",
+        )
+
+        assert build_session_key(msg) == "nanobot:telegram:dm:123"
+
+    def test_build_session_key_topic(self):
+        from nanobot.bus.events import InboundMessage
+
+        from nanobot_deep.langgraph.bridge import build_session_key
+
+        msg = InboundMessage(
+            channel="telegram",
+            sender_id="user123",
+            chat_id="123",
+            content="Hello",
+            metadata={"is_group": True, "is_forum": True, "message_thread_id": 456},
+        )
+
+        assert build_session_key(msg) == "nanobot:telegram:topic:123:456"
+
+    def test_build_session_key_group(self):
+        from nanobot.bus.events import InboundMessage
+
+        from nanobot_deep.langgraph.bridge import build_session_key
+
+        msg = InboundMessage(
+            channel="telegram",
+            sender_id="user123",
+            chat_id="123",
+            content="Hello",
+            metadata={"is_group": True},
+        )
+
+        assert build_session_key(msg) == "nanobot:telegram:group:123"
+
+
 class TestTranslateInboundToState:
     """Tests for translate_inbound_to_state function."""
 


### PR DESCRIPTION
## Summary
- Add `build_session_key()` function with Hermes-style session keys:
  - DM: `nanobot:telegram:dm:{chat_id}`
  - Group: `nanobot:telegram:group:{chat_id}`
  - Topic: `nanobot:telegram:topic:{chat_id}:{thread_id}`
- Extend SystemMessage with timestamp and location
- Add metadata dict to returned state for programmatic access

## Tests
- Added `TestBuildSessionKey` test class with DM, Topic, Group tests
- All 25 tests pass